### PR TITLE
Replace unmaintained react-spoiler-tag with custom react component

### DIFF
--- a/blog/2022-08-30-update2-0-alpha.mdx
+++ b/blog/2022-08-30-update2-0-alpha.mdx
@@ -4,9 +4,6 @@ authors: [ttin, team-lumi]
 tags: [update, 2-0, alpha, luminescent]
 ---
 
-import { Spoiler } from 'react-spoiler-tag'
-import 'react-spoiler-tag/dist/index.css'
-
 Trainers, the time has come.
 We apologize it's taken so long, but this essentially took a full rebuild of the entire storyline of the game. There's barely a single place in the game that hasn't been re-scripted. Thank you all so much for your patience.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-spoiler-tag": "^1.1.7"
+        "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "2.1.0"
@@ -10301,17 +10300,6 @@
         "react": ">=15"
       }
     },
-    "node_modules/react-spoiler-tag": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-spoiler-tag/-/react-spoiler-tag-1.1.7.tgz",
-      "integrity": "sha512-Y03w+YhbWNTWGZ/1PQMsIs9hVoDgvVq18fYh1LLksJ0r9HSzRBy8F5fxidV/LF5mzE1whVa3FtuNyA4PyKR1hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
     "node_modules/react-textarea-autosize": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
@@ -20590,12 +20578,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
-    },
-    "react-spoiler-tag": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-spoiler-tag/-/react-spoiler-tag-1.1.7.tgz",
-      "integrity": "sha512-Y03w+YhbWNTWGZ/1PQMsIs9hVoDgvVq18fYh1LLksJ0r9HSzRBy8F5fxidV/LF5mzE1whVa3FtuNyA4PyKR1hA==",
-      "requires": {}
     },
     "react-textarea-autosize": {
       "version": "8.4.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-spoiler-tag": "^1.1.7"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.1.0"

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -2,16 +2,11 @@ import React from 'react';
 // Import the original mapper
 import MDXComponents from '@theme-original/MDXComponents';
 import * as materialUI from '@mui/material';
-import { Spoiler } from 'react-spoiler-tag';
-
-// Set the spoilers default properties
-Spoiler.defaultProps = {
-  revealedColor: 'transparent'
-}
+import Spoiler from './SpoilerTag/SpoilerTag';
 
 export default {
   // Re-use the default mapping
   ...MDXComponents,
   ...materialUI,
-  spoiler: Spoiler,
+  Spoiler,
 };

--- a/src/theme/SpoilerTag/SpoilerTag.jsx
+++ b/src/theme/SpoilerTag/SpoilerTag.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import styles from './SpoilerTag.module.css';
+
+export default function SpoilerTag(props) {
+  return <span className={styles.spoiler}>{props.children}</span>;
+}

--- a/src/theme/SpoilerTag/SpoilerTag.module.css
+++ b/src/theme/SpoilerTag/SpoilerTag.module.css
@@ -1,0 +1,11 @@
+.spoiler {
+  background-color: rgb(68, 68, 68);
+  color: transparent;
+  user-select: none;
+  border-radius: 0.3em;
+}
+
+.spoiler:hover {
+  background-color: inherit;
+  color: inherit;
+}


### PR DESCRIPTION
# Motivation
`npm install` throws peer dependency errors because of `react-spoiler-tag` which is not compatible with react 17. Since it's a very simple component and we are currently only using it in ONE blog post - I replaced it with this stackoverflow solution https://stackoverflow.com/a/70820783/11143225 - styling is also almost the same.

# Problem
![image](https://user-images.githubusercontent.com/25965213/233207083-1a277461-8141-4566-b452-06310aa70632.png)

# Solution

Current implementation with react-spoiler-tag - spoiler on click
![image](https://user-images.githubusercontent.com/25965213/233207196-6e829e0d-0567-497a-86ff-1dcf3fc02bfa.png)

Custom implementation - spoiler on hover
![image](https://user-images.githubusercontent.com/25965213/233207242-44f6573e-ce0c-4d47-bc72-853c21a17541.png)
 