### PR TITLE
Feature/pokedex display egggroups

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "jest/globals": true
+    "jest/globals": true,
+    "es6": true
   },
   "plugins": ["jest"]
 }

--- a/src/components/Pokedex/PokemonEggGroups.jsx
+++ b/src/components/Pokedex/PokemonEggGroups.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import { getEggGroupNameById } from '../../utils/dex/egggroup';
+
+export const PokemonEggGroups = ({ eggGroupIds, sx }) => {
+  return (
+    <Box sx={{ ...sx }}>
+      <Typography sx={{ fontWeight: 800, fontSize: '0.8rem' }}>Egg Groups:</Typography>
+      <Container>
+        <Box display="flex" alignItems="center">
+          <img src="/img/pm0000_00_00_00_L.webp" alt="Pokemon Egg" width="16px" height="20px" />
+          {eggGroupIds.map((eggGroupId, i) => {
+            try {
+              const eggGroupName = getEggGroupNameById(eggGroupId);
+              return (
+                <Typography key={`eggGroupId-${eggGroupId}`} marginLeft="8px">
+                  {eggGroupName}
+                  {i < eggGroupIds.length - 1 && ','}
+                </Typography>
+              );
+            } catch (err) {
+              return <Typography key={`eggGroupId-${eggGroupId}`}>{err.message}</Typography>;
+            }
+          })}
+        </Box>
+      </Container>
+    </Box>
+  );
+};

--- a/src/components/Pokedex/index.js
+++ b/src/components/Pokedex/index.js
@@ -11,6 +11,8 @@ import { PokemonAccordion } from './PokemonAccordion';
 import { PokemonAlternativeFormsList } from './PokemonAlternativeFormsList';
 import { PokemonAbilities } from './PokemonAbilities';
 import { PokemonGenderRatio } from './PokemonGenderRatio';
+import { PokemonEggGroups } from './PokemonEggGroups';
+import { getEggGroupViaPokemonId } from '../../utils/dex/egggroup';
 
 export default function PokedexFeatures() {
   const [pokemonDexId, setPokemonDexId] = useState(1);
@@ -84,7 +86,10 @@ export default function PokedexFeatures() {
       </Container>
 
       <Container>
-        <PokemonGenderRatio genderDecimalValue={pokemonInfo.genderDecimalValue} />
+        <Box display="flex">
+          <PokemonEggGroups eggGroupIds={getEggGroupViaPokemonId(pokemonDexId)} sx={{ marginRight: '16px' }} />
+          <PokemonGenderRatio genderDecimalValue={pokemonInfo.genderDecimalValue} />
+        </Box>
       </Container>
 
       <Container>

--- a/src/components/Pokedex/index.js
+++ b/src/components/Pokedex/index.js
@@ -86,7 +86,7 @@ export default function PokedexFeatures() {
       </Container>
 
       <Container>
-        <Box display="flex">
+        <Box display="flex" sx={{ flexDirection: { xs: 'column', sm: 'row' } }}>
           <PokemonEggGroups eggGroupIds={getEggGroupViaPokemonId(pokemonDexId)} sx={{ marginRight: '16px' }} />
           <PokemonGenderRatio genderDecimalValue={pokemonInfo.genderDecimalValue} />
         </Box>

--- a/src/utils/dex/egggroup.js
+++ b/src/utils/dex/egggroup.js
@@ -1,25 +1,25 @@
 import { PersonalTable } from '../../../__gamedata';
 
-const EGG_GROUPS = [
-  'None',
-  'Monster',
-  'Water 1',
-  'Bug',
-  'Flying',
-  'Field',
-  'Fairy',
-  'Grass',
-  'Human-Like',
-  'Water 3',
-  'Mineral',
-  'Amorphous',
-  'Water 2',
-  'Ditto',
-  'Dragon',
-  'No Eggs',
-];
+const EGG_GROUPS = {
+  0: 'None',
+  1: 'Monster',
+  2: 'Water 1',
+  3: 'Bug',
+  4: 'Flying',
+  5: 'Field',
+  6: 'Fairy',
+  7: 'Grass',
+  8: 'Human-Like',
+  9: 'Water 3',
+  10: 'Mineral',
+  11: 'Amorphous',
+  12: 'Water 2',
+  13: 'Ditto',
+  14: 'Dragon',
+  15: 'No Eggs',
+};
 
-const POKEMON_BY_EGG_GROUP = PersonalTable.Personal.reduce(createPokemonByEggGroupMap, []);
+const POKEMON_IDS_BY_EGG_GROUP = PersonalTable.Personal.reduce(createPokemonByEggGroupMap, []);
 const HIGHEST_EGG_GROUP_ID = 15;
 
 function getEggGroupViaPokemonId(pokemonId = 0) {
@@ -53,10 +53,10 @@ function createPokemonByEggGroupMap(pokemonMap, currentPokemon) {
   return pokemonMap;
 }
 
-function getPokemonInEggGroup(eggGroupId = 0) {
+function getPokemonIdsInEggGroup(eggGroupId = 0) {
   if (!Number.isInteger(eggGroupId) || eggGroupId < 0 || eggGroupId > HIGHEST_EGG_GROUP_ID)
     throw new Error(`Bad eggGroupId: ${eggGroupId}`);
-  return Array.from(POKEMON_BY_EGG_GROUP[eggGroupId]); //Back to array for easier handling
+  return Array.from(POKEMON_IDS_BY_EGG_GROUP[eggGroupId]); //Back to array for easier handling
 }
 
-export { getPokemonInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId };
+export { getPokemonIdsInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId };

--- a/src/utils/dex/egggroup.js
+++ b/src/utils/dex/egggroup.js
@@ -1,0 +1,62 @@
+import { PersonalTable } from '../../../__gamedata';
+
+const EGG_GROUPS = [
+  'None',
+  'Monster',
+  'Water 1',
+  'Bug',
+  'Flying',
+  'Field',
+  'Fairy',
+  'Grass',
+  'Human-Like',
+  'Water 3',
+  'Mineral',
+  'Amorphous',
+  'Water 2',
+  'Ditto',
+  'Dragon',
+  'No Eggs',
+];
+
+const POKEMON_BY_EGG_GROUP = PersonalTable.Personal.reduce(createPokemonByEggGroupMap, []);
+const HIGHEST_EGG_GROUP_ID = 15;
+
+function getEggGroupViaPokemonId(pokemonId = 0) {
+  if (!Number.isInteger(pokemonId) || pokemonId < 0 || pokemonId > PersonalTable.Personal.length)
+    throw new Error(`Bad pokemonId: ${pokemonId}`);
+
+  const pokemonDetails = PersonalTable.Personal[pokemonId];
+  const eggGroup1 = pokemonDetails.egg_group1;
+  const eggGroup2 = pokemonDetails.egg_group2;
+  return eggGroup1 === eggGroup2 ? [eggGroup1] : [eggGroup1, eggGroup2];
+}
+
+function getEggGroupNameById(eggGroupId = 0) {
+  if (!Number.isInteger(eggGroupId) || eggGroupId < 0 || eggGroupId > HIGHEST_EGG_GROUP_ID)
+    throw new Error(`Bad eggGroupId: ${eggGroupId}`);
+  return EGG_GROUPS[eggGroupId];
+}
+
+function createPokemonByEggGroupMap(pokemonMap, currentPokemon) {
+  //Use sets so I don't have to handle duplicates, looking at you Unown
+  if (pokemonMap[currentPokemon.egg_group1] === undefined) {
+    pokemonMap[currentPokemon.egg_group1] = new Set();
+  }
+
+  if (pokemonMap[currentPokemon.egg_group2] === undefined) {
+    pokemonMap[currentPokemon.egg_group2] = new Set();
+  }
+
+  pokemonMap[currentPokemon.egg_group1].add(currentPokemon.id);
+  pokemonMap[currentPokemon.egg_group2].add(currentPokemon.id);
+  return pokemonMap;
+}
+
+function getPokemonInEggGroup(eggGroupId = 0) {
+  if (!Number.isInteger(eggGroupId) || eggGroupId < 0 || eggGroupId > HIGHEST_EGG_GROUP_ID)
+    throw new Error(`Bad eggGroupId: ${eggGroupId}`);
+  return Array.from(POKEMON_BY_EGG_GROUP[eggGroupId]); //Back to array for easier handling
+}
+
+export { getPokemonInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId };

--- a/src/utils/dex/egggroup.test.js
+++ b/src/utils/dex/egggroup.test.js
@@ -1,4 +1,4 @@
-import { getPokemonInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId } from './egggroup';
+import { getPokemonIdsInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId } from './egggroup';
 
 describe('Dex Utils Egg Group Tests', () => {
   describe('getEggGroupViaPokemonId', () => {
@@ -95,7 +95,7 @@ describe('Dex Utils Egg Group Tests', () => {
 
     validIds.forEach(({ id, count }) => {
       test(`should return an array of ${count} Pokemon for egg group ID ${id}`, () => {
-        const result = getPokemonInEggGroup(id);
+        const result = getPokemonIdsInEggGroup(id);
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBe(count);
       });
@@ -103,7 +103,7 @@ describe('Dex Utils Egg Group Tests', () => {
 
     invalidIds.forEach(({ id, message }) => {
       test(`should throw an error for invalid egg group ID ${id}`, () => {
-        expect(() => getPokemonInEggGroup(id)).toThrow(Error(message));
+        expect(() => getPokemonIdsInEggGroup(id)).toThrow(Error(message));
       });
     });
   });

--- a/src/utils/dex/egggroup.test.js
+++ b/src/utils/dex/egggroup.test.js
@@ -1,0 +1,110 @@
+import { getPokemonInEggGroup, getEggGroupNameById, getEggGroupViaPokemonId } from './egggroup';
+
+describe('Dex Utils Egg Group Tests', () => {
+  describe('getEggGroupViaPokemonId', () => {
+    const testData = [
+      { pokemonId: 0, expected: [0] },
+      { pokemonId: 1, expected: [1, 7] },
+      { pokemonId: 2, expected: [1, 7] },
+      { pokemonId: 3, expected: [1, 7] },
+      { pokemonId: 150, expected: [15] },
+      { pokemonId: -1, expectedError: 'Bad pokemonId: -1' },
+      { pokemonId: 'a', expectedError: 'Bad pokemonId: a' },
+    ];
+
+    testData.forEach(({ pokemonId, expected, expectedError }) => {
+      const testTitle = `returns ${JSON.stringify(expected)} for pokemonId ${pokemonId}`;
+      if (expectedError) {
+        test(testTitle, () => {
+          expect(() => getEggGroupViaPokemonId(pokemonId)).toThrow(expectedError);
+        });
+      } else {
+        test(testTitle, () => {
+          expect(getEggGroupViaPokemonId(pokemonId)).toEqual(expected);
+        });
+      }
+    });
+  });
+
+  describe('getEggGroupNameById', () => {
+    const testData = [
+      { eggGroupId: 0, expected: 'None' },
+      { eggGroupId: 1, expected: 'Monster' },
+      { eggGroupId: 2, expected: 'Water 1' },
+      { eggGroupId: 7, expected: 'Grass' },
+      { eggGroupId: 14, expected: 'Dragon' },
+      { eggGroupId: -1, expectedError: 'Bad eggGroupId: -1' },
+      { eggGroupId: 'a', expectedError: 'Bad eggGroupId: a' },
+      { eggGroupId: 100, expectedError: `Bad eggGroupId: 100` },
+    ];
+
+    testData.forEach(({ eggGroupId, expected, expectedError }) => {
+      const testTitle = `returns "${expected}" for eggGroupId ${eggGroupId}`;
+      if (expectedError) {
+        test(testTitle, () => {
+          expect(() => getEggGroupNameById(eggGroupId)).toThrow(expectedError);
+        });
+      } else {
+        test(testTitle, () => {
+          expect(getEggGroupNameById(eggGroupId)).toBe(expected);
+        });
+      }
+    });
+  });
+
+  describe('getEggGroupNameById', () => {
+    const validIds = [
+      { id: 0, name: 'None' },
+      { id: 5, name: 'Field' },
+      { id: 10, name: 'Mineral' },
+    ];
+
+    const invalidIds = [
+      { id: 'not a number', message: 'Bad eggGroupId: not a number' },
+      { id: -5, message: 'Bad eggGroupId: -5' },
+      { id: 123, message: 'Bad eggGroupId: 123' },
+      { id: 16, message: `Bad eggGroupId: ${16}` },
+    ];
+
+    validIds.forEach(({ id, name }) => {
+      test(`should return the correct egg group name for ID ${id}`, () => {
+        const result = getEggGroupNameById(id);
+        expect(result).toBe(name);
+      });
+    });
+
+    invalidIds.forEach(({ id, message }) => {
+      test(`should throw an error for invalid ID ${id}`, () => {
+        expect(() => getEggGroupNameById(id)).toThrow(Error(message));
+      });
+    });
+  });
+
+  describe('getPokemonInEggGroup', () => {
+    const validIds = [
+      { id: 0, count: 1 },
+      { id: 5, count: 404 },
+      { id: 10, count: 99 },
+    ];
+
+    const invalidIds = [
+      { id: 'not a number', message: 'Bad eggGroupId: not a number' },
+      { id: -5, message: 'Bad eggGroupId: -5' },
+      { id: 123, message: 'Bad eggGroupId: 123' },
+    ];
+
+    validIds.forEach(({ id, count }) => {
+      test(`should return an array of ${count} Pokemon for egg group ID ${id}`, () => {
+        const result = getPokemonInEggGroup(id);
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBe(count);
+      });
+    });
+
+    invalidIds.forEach(({ id, message }) => {
+      test(`should throw an error for invalid egg group ID ${id}`, () => {
+        expect(() => getPokemonInEggGroup(id)).toThrow(Error(message));
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation
There is no way to see a Pokemon's  Egg groups.

# Additional Information
Branch is based on #48. Names are not clickable yet.

# Solution
<img width="435" alt="image" src="https://user-images.githubusercontent.com/25965213/235297478-f7074a26-56b1-4449-b5ec-529825f492db.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/25965213/235297485-f48cdbca-3391-430d-951b-167888380d46.png">

Closes #29 