### PR TITLE
Move interpretation bugfix

### DIFF
--- a/src/utils/dex/index.js
+++ b/src/utils/dex/index.js
@@ -9,7 +9,7 @@ import {
   getTechMachineLearnset,
   getMoveProperties,
   getPokemonLearnset,
-  parseTmLearnsetSection,
+  getTMCompatibility,
 } from './moves';
 import {
   getPokemonMonsnoFromName,
@@ -48,7 +48,7 @@ function getPokemonInfo(monsno = 0) {
     ability1: getAbilityString(p.tokusei1),
     ability2: getAbilityString(p.tokusei2),
     abilityH: getAbilityString(p.tokusei3),
-    tmLearnset: getTechMachineLearnset(p.machine1, p.machine2, p.machine3, p.machine4),
+    tmLearnset: getTechMachineLearnset(p.id),
     prettyBaseStats: formatBaseStats(p),
     baseStats: {
       hp: p.basic_hp,
@@ -76,7 +76,7 @@ export {
   getGrassKnotPower,
   getImage,
   formatBaseStats,
-  parseTmLearnsetSection,
+  getTMCompatibility,
   getPokemonIdFromMonsNoAndForm,
   getPokemonInfo,
   makeSmogonAbilityObject,

--- a/src/utils/dex/moves.js
+++ b/src/utils/dex/moves.js
@@ -135,9 +135,6 @@ function getTechMachineLearnset(pokemonId = 0) {
 
     const legalitySetValue = ItemTable.Item[tm.itemNo].group_id;
     const isLearnable = learnset[legalitySetValue - 1];
-    if (tm.wazaNo === 216) {
-      console.log(legalitySetValue, learnset[legalitySetValue - 1], isLearnable);
-    }
 
     if (isLearnable) {
       canLearn.push({ level: 'tm', moveId: tm.wazaNo });

--- a/src/utils/dex/moves.test.js
+++ b/src/utils/dex/moves.test.js
@@ -7,7 +7,7 @@ import {
   getTechMachineLearnset,
   getMoveProperties,
   getPokemonLearnset,
-  parseTmLearnsetSection,
+  getTMCompatibility,
 } from './moves';
 
 describe('Dex Utils Move Getters', () => {
@@ -116,32 +116,161 @@ describe('Dex Utils Move Getters', () => {
       expect(getEggMoves(2)).toEqual([]);
     });
   });
-  describe('parseTmLearnsetSection', () => {
-    it('returns the correct binary string for a decimal number', () => {
-      expect(parseTmLearnsetSection(2150467360)).toBe('00000100111000011011010000000001');
-      expect(parseTmLearnsetSection(3149832)).toBe('00000000000001000000001000000011');
-      expect(parseTmLearnsetSection(2418017312)).toBe('00000100001000000000010000001001');
+  describe('getTMCompatibility', () => {
+    const TM_LEARNSET = [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ];
+
+    it('returns the correct array for a decimal number', () => {
+      expect(getTMCompatibility(3)).toStrictEqual(TM_LEARNSET);
     });
 
     it('returns a 32-character string for any input', () => {
-      const binaryString = parseTmLearnsetSection(8);
-      expect(binaryString).toHaveLength(32);
+      const learnsetArray = getTMCompatibility(8);
+      expect(learnsetArray).toHaveLength(128);
     });
   });
   describe('getTechMachineLearnset', () => {
     it('returns an empty array when no TMs are learned', () => {
-      expect(getTechMachineLearnset(0, 0, 0, 0)).toEqual([]);
+      expect(getTechMachineLearnset(0)).toEqual([]);
     });
 
     it('returns an array of TM moves when one or more TMs are learned', () => {
-      const learnset = getTechMachineLearnset(2150467360, 3149832, 2418017312, 0);
+      const learnset = getTechMachineLearnset(3);
       expect(learnset).toContainEqual({ level: 'tm', moveId: 92 });
       expect(learnset).toContainEqual({ level: 'tm', moveId: 331 });
-      expect(learnset).toHaveLength(19);
+      expect(learnset).toHaveLength(33);
     });
 
     it('ignores TMs that the Pokémon cannot learn', () => {
-      const learnset = getTechMachineLearnset(2150467360, 3149832, 2418017312, 0);
+      const learnset = getTechMachineLearnset(3);
       expect(learnset).not.toContainEqual({ level: 'tm', moveId: 3 });
       expect(learnset).not.toContainEqual({ level: 'tm', moveId: 4 });
     });


### PR DESCRIPTION
- TM Learnsets were being read in incorrectly.
- Move generation based on learnset was broken due to poor indexing.
- Tested on dev machine, seemed fine.