### PR TITLE
New mapper rewrite

### DIFF
--- a/__gamedata/gamedata2.0/static_area_locations.json
+++ b/__gamedata/gamedata2.0/static_area_locations.json
@@ -1583,7 +1583,7 @@
       "pokemonName": "Uxie"
     }
   ],
-  "326": [
+  "325": [
     {
       "routeName": "Lake Verity Cavern",
       "encounterType": "Legendaries",
@@ -1591,7 +1591,7 @@
       "minLevel": 60,
       "maxLevel": 60,
       "encounterTypeIndex": 0,
-      "zoneId": 326,
+      "zoneId": 325,
       "pokemonName": "Mesprit"
     }
   ],

--- a/__gamedata/gamedata3.0/static_area_locations.json
+++ b/__gamedata/gamedata3.0/static_area_locations.json
@@ -1583,7 +1583,7 @@
       "pokemonName": "Uxie"
     }
   ],
-  "326": [
+  "325": [
     {
       "routeName": "Lake Verity Cavern",
       "encounterType": "Legendaries",
@@ -1591,7 +1591,7 @@
       "minLevel": 60,
       "maxLevel": 60,
       "encounterTypeIndex": 0,
-      "zoneId": 326,
+      "zoneId": 325,
       "pokemonName": "Mesprit"
     }
   ],

--- a/__gamedata/gamedataVanilla/static_area_locations.json
+++ b/__gamedata/gamedataVanilla/static_area_locations.json
@@ -1583,7 +1583,7 @@
       "pokemonName": "Uxie"
     }
   ],
-  "326": [
+  "325": [
     {
       "routeName": "Lake Verity Cavern",
       "encounterType": "Legendaries",
@@ -1591,7 +1591,7 @@
       "minLevel": 60,
       "maxLevel": 60,
       "encounterTypeIndex": 0,
-      "zoneId": 326,
+      "zoneId": 325,
       "pokemonName": "Mesprit"
     }
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -263,6 +263,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['bash', 'diff', 'json'],
       },
       colorMode: {
         defaultMode: 'dark',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "luminescent-team",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.4.0",
+        "@bucky24/react-canvas": "^3.2.0",
         "@docusaurus/core": "^3.9.2",
         "@docusaurus/plugin-client-redirects": "^3.9.2",
         "@docusaurus/preset-classic": "^3.9.2",
@@ -2094,9 +2096,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2159,11 +2161,90 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.0.tgz",
+      "integrity": "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.7",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bucky24/react-canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bucky24/react-canvas/-/react-canvas-3.2.0.tgz",
+      "integrity": "sha512-aO09IgfwJgmOL2dO0gvFCWmioQ5xaywCidwrxbnkmqcByKQIdcVBdCbjJK5PreqBJpcIT6Oy+rScuj0RdOL4qw==",
+      "license": "ISC",
+      "dependencies": {
+        "prop-types": "15.7.2",
+        "react-dom": "18.2.0",
+        "react-fast-compare": "3.2.0"
+      },
+      "peerDependencies": {
+        "react": "18.x.x"
+      }
+    },
+    "node_modules/@bucky24/react-canvas/node_modules/prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -4871,6 +4952,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -20997,6 +21116,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -22997,6 +23122,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -25238,9 +25372,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.28.6",
@@ -25283,11 +25417,56 @@
         "@babel/helper-validator-identifier": "^7.28.5"
       }
     },
+    "@base-ui/react": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.0.tgz",
+      "integrity": "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==",
+      "requires": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.7",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      }
+    },
+    "@base-ui/utils": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==",
+      "requires": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      }
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@bucky24/react-canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bucky24/react-canvas/-/react-canvas-3.2.0.tgz",
+      "integrity": "sha512-aO09IgfwJgmOL2dO0gvFCWmioQ5xaywCidwrxbnkmqcByKQIdcVBdCbjJK5PreqBJpcIT6Oy+rScuj0RdOL4qw==",
+      "requires": {
+        "prop-types": "15.7.2",
+        "react-dom": "18.2.0",
+        "react-fast-compare": "3.2.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -26775,6 +26954,36 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
       "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "requires": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "requires": {
+        "@floating-ui/dom": "^1.7.6"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -37130,6 +37339,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
+    "reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
+    },
     "resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -38481,6 +38695,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,15 @@
     "test:ci": "jest -c ./jest-ci.config.js",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lint": "eslint . --ext .jsx,.js"
+    "lint": "eslint . --ext .jsx,.js",
+    "clean": "rm -rf node_modules",
+    "reinstall": "npm run clean && npm install",
+    "rebuild": "npm run clean && npm install && npm run build",
+    "check-mdx": "npx docusaurus-mdx-checker"
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.0",
+    "@bucky24/react-canvas": "^3.2.0",
     "@docusaurus/core": "^3.9.2",
     "@docusaurus/plugin-client-redirects": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",

--- a/src/components/Mapper/Encounters/EncounterTable.jsx
+++ b/src/components/Mapper/Encounters/EncounterTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
+import Link from '@docusaurus/Link';
 import {
   Table,
   TableBody,
@@ -13,6 +14,8 @@ import {
 
 import "../style.css";
 import { LINK_KEYS } from '../../../utils/dex/encountersConstants';
+import { normalizePokemonName } from '../../../utils/dex/name';
+import { GAMEDATA3 } from '../../../../__gamedata';
 
 const EncounterTable = ({ encounterList, pokemon }) => {
   const { colorMode, setColorMode } = useColorMode();
@@ -47,7 +50,11 @@ const EncounterTable = ({ encounterList, pokemon }) => {
                   key={index}
                   className={enc.pokemonName === pokemon ? highlightColor : ""}
                 >
-                  <TableCell>{enc.pokemonName}</TableCell>
+                  <TableCell>
+                    <Link to={`/pokedex/${normalizePokemonName(enc.pokemonName, GAMEDATA3)}`}>
+                      {enc.pokemonName}
+                    </Link>
+                  </TableCell>
                   <TableCell>
                     {enc.minLevel !== enc.maxLevel
                       ? `${enc.minLevel} - ${enc.maxLevel}`

--- a/src/components/Mapper/Location.jsx
+++ b/src/components/Mapper/Location.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Rect, Text } from "@bucky24/react-canvas";
+import { isLocationWithinBounds } from "./coordinates";
+import { CLEAR_MODE } from "./Mapper";
+
+export const Location = ({
+  location,
+  mouseCoords,
+  selectedLocation,
+  encounterLocations,
+  colors
+}) => {
+  const isSelected = selectedLocation === location.zoneId;
+  const isMouseOver = isLocationWithinBounds({
+    ...location,
+    x: location.x + 2,
+    y: location.y + 2,
+    width: location.width - 2,
+    height: location.height - 2,
+  }, mouseCoords);
+  const isEncounter = encounterLocations.some(arr => arr[1] === location.zoneId);
+
+  const fill = isSelected || isMouseOver || isEncounter;
+  const showText = isMouseOver;
+
+  function getHoverFillStyle() {
+    const { r, g, b, a } = colors.hov;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+
+  function getSelFillStyle() {
+    const { r, g, b, a } = colors.sel;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+
+  function getEncFillStyle() {
+    const { r, g, b, a } = colors.enc;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  }
+
+  let color = colors.default;
+  if (isSelected) {
+    color = getSelFillStyle();
+  } else if (isMouseOver) {
+    color = getHoverFillStyle();
+  } else if (isEncounter) {
+    color = getEncFillStyle();
+  }
+
+  return (
+    <>
+      <Rect
+        x={location.x + 1}
+        y={location.y + 1}
+        x2={location.x + location.width - 1}
+        y2={location.y + location.height - 1}
+        color={color}
+        fill={fill}
+      />
+      {showText && (
+        <Text
+          x={location.x + location.width + 2}
+          y={location.y - 2}
+          font="18px Arial"
+          background
+          backgroundColor={'rgba(255, 255, 255, 0.8)'}
+        >
+          {location.name}
+        </Text>
+      )}
+    </>
+  );
+};

--- a/src/components/Mapper/Location.jsx
+++ b/src/components/Mapper/Location.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { Rect, Text } from "@bucky24/react-canvas";
 import { isLocationWithinBounds } from "./coordinates";
-import { CLEAR_MODE } from "./Mapper";
 
 export const Location = ({
   location,

--- a/src/components/Mapper/Mapper.jsx
+++ b/src/components/Mapper/Mapper.jsx
@@ -1,17 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
-import IconButton from '@mui/material/IconButton';
-import SettingsIcon from '@mui/icons-material/Settings';
+import { Canvas, Image, Rect } from '@bucky24/react-canvas';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 import {
-  MapperCoordinates,
-  getLocationCoordsFromName,
-  getLocationCoordsFromZoneId,
+  sortedCoordinates,
   getSelectedLocation,
-  isLocationExactlyEqual
 } from './coordinates';
 import { SearchBar } from './SearchBar';
-import { RodButtons, TimeOfDayButtons } from './Encounters/Buttons';
 import { MapperTabPanel } from './TabPanel/MapperTabPanel';
 import SettingsModal from './Settings/SettingsModal';
 import './style.css';
@@ -23,7 +18,6 @@ import {
   getHiddenItemsFromZoneID,
   getPokemonIdFromName
 } from '../../utils/dex';
-import { getZoneIdFromZoneName } from '../../utils/dex/location';
 import {
   getFixedShops,
   getItemPrice,
@@ -48,40 +42,32 @@ import {
 } from '../../utils/dex/encounters';
 import TrainersModal from './Trainers/TrainersModal';
 import { GAMEDATA3 } from '../../../__gamedata';
+import { Location } from './Location';
+import mapperImage from "../../../static/img/new_small_mapper.png";
 
 const canvasDimensions = {
   width: 1280,
   height: 720
 }
 
-const versionNumber = "Beta 1.1.2";
+const versionNumber = "Beta 1.2.0";
 
-function useDebouncedValue(value, delay) {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
+export const CLEAR_MODE = {
+  HIGHLIGHT: "highlight",
+  SELECT: "select",
+  ENCOUNTER: "enc",
+};
 
 export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
   const isBrowser = useIsBrowser();
   if (!isBrowser) {
     return null;
   }
-  const [rect, setRect] = useState(null);
-  const [hoveredZone, setHoveredZone] = useState(null);
-  const [selectedZone, setSelectedZone] = useState(null);
-  const [selectedZoneId, setSelectedZoneId] = useState(null);
-  const locationId = useRef("");
+  const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0 });
+  const [selectedLocation, setSelectedLocation] = useState(null);
+  const [selectedZone, setSelectedZone] = useState("");
+
+  const [encounterLocations, setEncounterLocations] = useState([]);
   const [encOptions, setEncOptions] = useState({
     swarm: false,
     radar: false,
@@ -90,51 +76,19 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
     rod: "1",
   });
 
-  const [selectedPokemon, setSelectedPokemon] = useState(pokemonList[0] || '');
+  const [selectedPokemon, setSelectedPokemon] = useState(null);
   const [pokemonName, setPokemonName] = useState('');
-  const completedPokemonName = useDebouncedValue(pokemonName, 1500);
 
-  const selectedRef = useRef(selectedZone);
   const [selectedTrainer, setSelectedTrainer] = useState(null);
-
-  useEffect(() => {
-    if (selectedRef.current !== selectedZone) {
-      setSelectedTrainer(null);
-      selectedRef.current = selectedZone;
-    }
-  }, [selectedZone]);
-
+  const [trainerList, setTrainerList] = useState([]);
   const [showTrainerModal, setShowTrainerModal] = useState(false);
-  const openTrainerModal = () => {
-    setShowTrainerModal(true);
-  };
-  const closeTrainerModal = () => {
-    setShowTrainerModal(false);
-  };
 
-  let originalImageData = {
-    highlight: {},
-    select: {},
-    enc: {},
-  };
-  let previousRectangle = {
-    highlight: null,
-    select: null,
-    enc: null,
-  };
-
-  let colorSettings = {
+  const [showSettings, setShowSettings] = useState(false);
+  const [colors, setColors] = useState({
     hov: { r: 247, g: 100, b: 200, a: 0.7 },
     sel: { r: 72, g: 113, b: 247, a: 0.8 },
     enc: { r: 247, g: 0, b: 0, a: 0.7 },
-  }
-
-  const [locationList, setLocationList] = useState([]);
-  const [showSettings, setShowSettings] = useState(false);
-  const [colors, setColors] = useState({
-    hov: { r: 247, g: 148, b: 72, a: 0.7 },
-    sel: { r: 72, g: 113, b: 247, a: 0.8 },
-    enc: { r: 247, g: 0, b: 0, a: 0.7 },
+    default: "transparent"
   });
 
   const [encounterList, setEncounterList] = useState({
@@ -144,7 +98,6 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
     honey: [],
     event: [],
   });
-  const [trainerList, setTrainerList] = useState([]);
   const [fieldItemsList, setFieldItems] = useState([]);
   const [hiddenItemsList, setHiddenItems] = useState([]);
   const [shopItemsList, setShopItems] = useState([]);
@@ -152,345 +105,23 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
   const [fixedShopList, setFixedShops] = useState([]);
   const [heartScaleShopList, setHeartScaleShop] = useState([]);
 
-  const canvasRef = useRef(null);
-  const CLEAR_MODE = {
-    HIGHLIGHT: "highlight",
-    SELECT: "select",
-    ENCOUNTER: "enc",
-  }
-  //Component onMount
-  useEffect(() => {
-    const context = canvasRef.current.getContext('2d', {willReadFrequently: true});
-    const image = new Image();
-    image.src = require('@site/static/img/new_small_mapper.png').default;
-    image.onload = () => {
-      context.drawImage(image, 0, 0);
-      drawOverlay(context);
-    };
-
-  }, []) // Empty dependency array means this effect runs once after the initial render
-
-  function drawOverlay(ctx) {
-    MapperCoordinates.forEach(coord => {
-      // Draw zone outlines
-      ctx.beginPath();
-      ctx.moveTo(coord.x, coord.y);
-      ctx.lineTo(coord.x + coord.width, coord.y);
-      ctx.lineTo(coord.x + coord.width, coord.y + coord.height);
-      ctx.lineTo(coord.x, coord.y + coord.height);
-      ctx.closePath();
-      ctx.strokeStyle = 'rgba(0, 0, 0, 1)';
-      ctx.lineWidth = 1;
-      ctx.stroke();
-    });
-  };
-
-  /** Listener Events for the Canvas updates */
-  const updateLocationDataFromDropdown = (event) => {
-    // This is using the custom event that was created by the SearchBar
-    // After adding a listener, this is used to directly interact with the canvas
-    // This CANNOT pull the state from a useState or other async func.
-    // You must add a customEvent alongside where a state is updated
-    const selectedName = event.detail;
-    if (!selectedName) {
-      return;
-    }
-    const location = getLocationCoordsFromName(selectedName);
-    const locationCheck = { x: location.x, y: location.y, width: location.width, height: location.height}
-
-    for (let key in previousRectangle) {
-      if (previousRectangle[key] === locationCheck && previousRectangle[key] !== null) {
-        // This is to delete any highlights that are present in the current area
-        // specifically enc highlights when that comes up.
-        clearRect(key);
-      }
-    }
-    if(previousRectangle.select !== null) {
-      clearRect(CLEAR_MODE.SELECT);
-    }
-    drawRect(location, CLEAR_MODE.SELECT);
-    previousRectangle.select = { x: location.x, y: location.y, width: location.width, height: location.height };
-    locationId.current = location.zoneId;
-
-    setEncounterList(setAllEncounters(location.zoneId));
-    setTrainerList(getTrainersFromZoneId(location.zoneId));
-
-    setFieldItems(getFieldItemsFromZoneID(location.zoneId));
-    setHiddenItems(getHiddenItemsFromZoneID(location.zoneId));
-    setShopItems(getRegularShopItems(location.zoneId));
-    setScriptItems(getScriptItems(location.zoneId));
-    setFixedShops(getFixedShops(location.zoneId));
-    setHeartScaleShop(getHeartScaleShopItems(location.zoneId));
-  };
-
-  const updatePokemonLocationsFromDropdown = (event) => {
-    // This is using the custom event that was created by the SearchBar
-    // After adding a listener, this is used to directly interact with the canvas
-    // This CANNOT pull the state from a useState or other async func.
-    // You must add a customEvent alongside where a state is updated
-    const selectedName = event.detail;
-    if (!selectedName) {
-      return;
-    }
-    const locations = getMapperRoutesFromPokemonId(selectedName.id);
-    const locationChecks = locations.map(([locationName, zoneId]) => {
-      const zoneLocationCoords = getLocationCoordsFromZoneId(zoneId);
-      const locationCoords = getLocationCoordsFromName(locationName);
-      if (zoneLocationCoords) {
-        const locationCheck = {
-          name: locationName,
-          x: zoneLocationCoords.x,
-          y: zoneLocationCoords.y,
-          width: zoneLocationCoords.width,
-          height: zoneLocationCoords.height,
-          zoneId: zoneLocationCoords.zoneId,
-          zone: "",
-        };
-        return locationCheck
-      } else if (locationCoords) {
-        const locationCheck = {
-          name: locationName,
-          x: locationCoords.x,
-          y: locationCoords.y,
-          width: locationCoords.width,
-          height: locationCoords.height,
-          zoneId: location.zoneId,
-          location: "",
-        };
-        return locationCheck
-      }
-      return null;
-    });
-    const prevLocations = previousRectangle.enc // There are multiple rectangles that are highlighted
-    const prevSelected = previousRectangle.select;
-    if (prevLocations) {
-      for (const locationIndex in prevLocations) {
-        if (
-          prevSelected &&
-          !isLocationExactlyEqual(
-            prevLocations[locationIndex],
-            prevSelected
-          )
-        ) {
-          clearRect(CLEAR_MODE.ENCOUNTER, prevLocations[locationIndex]);
-        } else {
-          clearRect(CLEAR_MODE.ENCOUNTER, prevLocations[locationIndex]);
-          drawRect(prevLocations[locationIndex], CLEAR_MODE.SELECT)
-        }
-      }
-      previousRectangle.enc = null;
-    }
-
-    for (const locationIndex in locationChecks) {
-      const location = locationChecks[locationIndex];
-      if (location) {
-        if (location.zoneId !== locationId.current && location.name !== hoveredZone) {
-          drawRect(location, CLEAR_MODE.ENCOUNTER);
-        } else if (location.name === hoveredZone) {
-          drawRect(location);
-        } else if (location.zoneId === locationId.current) {
-          drawRect(location, CLEAR_MODE.SELECT);
-        }
-      }
-    }
-  };
-
-  const updateColorSettings = (event) => {
-    const newColorSettings = event.detail;
-    colorSettings = newColorSettings;
-    const prevLocations = previousRectangle.enc // There are multiple rectangles that are highlighted
-    const prevHighlight = previousRectangle.highlight;
-    const prevSelected = previousRectangle.select;
-    if (prevLocations) {
-      for (const locationIndex in prevLocations) {
-        if (
-          prevHighlight &&
-          isLocationExactlyEqual(
-            prevLocations[locationIndex],
-            prevHighlight
-          )
-        ) {
-          clearRect(CLEAR_MODE.HIGHLIGHT);
-          setHoveredZone(null);
-          previousRectangle.highlight = null;
-        }
-        if (
-          prevSelected &&
-          !isLocationExactlyEqual(
-            prevLocations[locationIndex],
-            prevSelected
-          )
-        ) {
-          clearRect(CLEAR_MODE.ENCOUNTER, prevLocations[locationIndex]);
-        } else {
-          clearRect(CLEAR_MODE.ENCOUNTER, prevLocations[locationIndex]);
-        }
-      }
-      previousRectangle.enc = null;
-    }
-    if (previousRectangle.select !== null) {
-      const location = previousRectangle.select;
-      drawRect(location, CLEAR_MODE.SELECT);
-    }
-    setPokemonName("Bulbasaur");
-    setSelectedPokemon(pokemonList[0])
-  }
-
-  const handleClick = (event) => {
-    if(rect === null) {
-      console.error('Bad Rect:', rect, canvasRef.current)
-      return setRect(canvasRef.current.getBoundingClientRect());
-    }
-
-    let scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-    let scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-    const x = event.clientX - rect.left + scrollLeft;
-    const y = event.clientY - rect.top + scrollTop;
-
-    const location = getSelectedLocation( x,y )
-    if(location === null || location.length === 0) return;
-
-    if (previousRectangle.highlight !== null) {
-      // Make sure to clear any lower hierarchy rects before setting higher ones
-      // If this is not done, the lower mode's highlight will be set as the previous state for the higher mode
-      // Here's how the bug would come up:
-      // 1. Hover over an area.
-      // 2. Select that area.
-      // 3. Hover over a different area.
-      // 4. Select that different area.
-      // 5. From this you'll see how the first area selected will have the hover color.
-      // This will also affect any future areas in the same way.
-      // We want the old selected area to not have the hover's color.
-      // See clearRect for hierarchy info.
-      clearRect(CLEAR_MODE.HIGHLIGHT);
-    }
-    if (previousRectangle.enc !== null) {
-      const selectedEnc = previousRectangle.enc.find(
-        (encLocation) => {
-          return (isLocationExactlyEqual(location, encLocation));
-        }
-      )
-      if (selectedEnc) {
-        clearRect(CLEAR_MODE.ENCOUNTER, selectedEnc);
-      }
-    }
-    if(previousRectangle.select !== null) {
-      clearRect(CLEAR_MODE.SELECT);
-    }
-    drawRect(location, CLEAR_MODE.SELECT); // Change the fill color
-    previousRectangle.select = { x: location.x, y: location.y, width: location.width, height: location.height };
-
-    locationId.current = location.zoneId;
-    setSelectedZone(location.name);
-    setSelectedZoneId(location.zoneId)
-    setEncounterList(setAllEncounters(location.zoneId));
-    setTrainerList(getTrainersFromZoneId(location.zoneId));
-
-    setFieldItems(getFieldItemsFromZoneID(location.zoneId));
-    setHiddenItems(getHiddenItemsFromZoneID(location.zoneId));
-    setShopItems(getRegularShopItems(location.zoneId));
-    setScriptItems(getScriptItems(location.zoneId));
-    setFixedShops(getFixedShops(location.zoneId));
-    setHeartScaleShop(getHeartScaleShopItems(location.zoneId));
-  };
-
-  function handleMouseMove(event) {
-    if(rect === null) {//Shouldn't happen but let's make sure
-      return setRect(canvasRef.current.getBoundingClientRect());
-    }
-
-    // This system allows mobile users to make use of the mapper too
-    let scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-    let scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-    const mouseX = event.clientX - rect.left + scrollLeft;
-    const mouseY = event.clientY - rect.top + scrollTop;
-
-    const location = getSelectedLocation(mouseX, mouseY);
-    if (location && location.zoneId !== locationId.current) {
-      setHoveredZone(location.name);
-      drawRect(location); // Change the fill color
-    } else if (location && location.zoneId === locationId.current) {
-      // This prevents the selected location from being highlighted by the hover color
-      drawRect(location, CLEAR_MODE.SELECT);
-    } else {
-      if (location && previousRectangle.enc !== null) {
-        const hoveredEnc = previousRectangle.enc.find(
-          (encLocation) => {
-            return (isLocationExactlyEqual(location, encLocation));
-          }
-        )
-        if (hoveredEnc) {
-          clearRect(CLEAR_MODE.ENCOUNTER, hoveredEnc);
-        }
-      }
-      setHoveredZone(null);
-      if (previousRectangle.highlight !== null) {
-        clearRect(CLEAR_MODE.HIGHLIGHT);
-        previousRectangle.highlight = null;
-      }
-    }
-  }
-
-  const handleMouseLeave = () => {
-    // Clear the hovered zone when mouse leaves
-    setHoveredZone(null);
-    if (previousRectangle.highlight !== null) {
-      clearRect(CLEAR_MODE.HIGHLIGHT);
-    }
-    if (previousRectangle.enc !== null) {
-      clearRect(CLEAR_MODE.ENCOUNTER);
-    }
-  };
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (canvas) {
-      // Get the bounding rectangle of the canvas
-      const r = canvas.getBoundingClientRect();
-      setRect(r);
-
-      // The passLocationNameToParent event was required so that the child could update the DOM
-      // This listener is created in the SearchBar.jsx and is listened to here
-      // This is how you would allow a useState from react to partially interact with the canvas
-      // Partially because useState is async and this is direct dom manipulation.
-      const eventListener = (locationNameEvent) => updateLocationDataFromDropdown(locationNameEvent);
-      const pokemonLocationsListener = (pokemonName) => updatePokemonLocationsFromDropdown(pokemonName);
-      const colorListener = (changeColorSettings) => updateColorSettings(changeColorSettings);
-
-      canvas.addEventListener('click', handleClick);
-      canvas.addEventListener('mousemove', handleMouseMove);
-      canvas.addEventListener('mouseleave', handleMouseLeave);
-      canvas.addEventListener('passLocationNameToParent', eventListener);
-      canvas.addEventListener('passPokemonNameLocation', pokemonLocationsListener);
-      canvas.addEventListener('changeColorSettings', colorListener);
-
-      // Clean up the event listener when the component is unmounted
-      return () => {
-        canvas.removeEventListener('click', handleClick);
-        canvas.removeEventListener('mousemove', handleMouseMove);
-        canvas.removeEventListener('mouseleave', handleMouseLeave);
-        canvas.removeEventListener('passLocationNameToParent', eventListener);
-        canvas.removeEventListener('passPokemonNameLocation', pokemonLocationsListener);
-        canvas.removeEventListener('changeColorSettings', colorListener);
-      };
-    }
-  }, [canvasRef.current]); // Add canvasRef.current to the dependency array
-
+  const locationId = useRef(null);
   useEffect(() => {
     if(locationId !== null) {
       setEncounterList(setAllEncounters(locationId.current))
     }
-  }, [encOptions, selectedZoneId])
+  }, [encOptions]);
 
   useEffect(() => {
-    setLocationList(getMapperRoutesFromPokemonId(getPokemonIdFromName(completedPokemonName)))
-  }, [completedPokemonName])
+    setEncounterLocations(getMapperRoutesFromPokemonId(selectedPokemon?.id));
+  }, [selectedPokemon]);
 
-  useEffect(() => {
-    setTrainerList(getTrainersFromZoneId(selectedZoneId) || []) ;
-  }, [selectedZoneId])
+  const openTrainerModal = () => {
+    setShowTrainerModal(true);
+  };
+  const closeTrainerModal = () => {
+    setShowTrainerModal(false);
+  };
 
   const handleOptionChange = (option, value) => {
     setEncOptions({
@@ -587,95 +218,51 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
     }
   }
 
-  function getHoverFillStyle() {
-    const { r, g, b, a } = colorSettings.hov;
-    return `rgba(${r}, ${g}, ${b}, ${a})`;
-  }
+  const handleNewMouseMove = ({ x, y, button }) => {
+    setMouseCoords({ x, y });
+  };
 
-  function getSelFillStyle() {
-    const { r, g, b, a } = colorSettings.sel;
-    return `rgba(${r}, ${g}, ${b}, ${a})`;
-  }
-
-  function getEncFillStyle() {
-    const { r, g, b, a } = colorSettings.enc;
-    return `rgba(${r}, ${g}, ${b}, ${a})`;
-  }
-
-  function drawRect(location, mode=CLEAR_MODE.HIGHLIGHT) {
-    //If there was no previous rectangle, don't clear it
-    if(previousRectangle[mode] !== null && mode !== CLEAR_MODE.ENCOUNTER) {
-      clearRect(mode);
-    }
-    const { x, y, width, height } = location;
-
-    const modeMap = {
-      highlight: getHoverFillStyle(),
-      select: getSelFillStyle(),
-      enc: getEncFillStyle()
-    };
-
-    const ctx = canvasRef.current.getContext('2d', {willReadFrequently: true});
-
-    //Store the important data
-    if (mode === CLEAR_MODE.ENCOUNTER) {
-      if (previousRectangle[mode] !== null) {
-        previousRectangle[mode] = [...previousRectangle[mode], {x, y, width, height}];
-        originalImageData[mode] = [...originalImageData[mode], ctx.getImageData(x, y, width, height)];
-      } else {
-        previousRectangle[mode] = [{x, y, width, height}];
-        originalImageData[mode] = [ctx.getImageData(x, y, width, height)];
-      }
+  const handleMouseUpClick = ({ x, y }) => {
+    const location = getSelectedLocation(x, y);
+    if (location) {
+      setSelectedLocation(location.zoneId);
+      locationId.current = location.zoneId;
+      setTrainerList(getTrainersFromZoneId(location.zoneId) || []);
+      setEncounterList(setAllEncounters(location.zoneId) || []);
+      setSelectedZone(location.name);
+      setFieldItems(getFieldItemsFromZoneID(location.zoneId));
+      setHiddenItems(getHiddenItemsFromZoneID(location.zoneId));
+      setShopItems(getRegularShopItems(location.zoneId));
+      setScriptItems(getScriptItems(location.zoneId));
+      setFixedShops(getFixedShops(location.zoneId));
+      setHeartScaleShop(getHeartScaleShopItems(location.zoneId));
     } else {
-      previousRectangle[mode] = {x, y, width, height};
-      originalImageData[mode] = ctx.getImageData(x, y, width, height);
+      setSelectedLocation(null);
+      locationId.current = null;
+      setTrainerList([]);
+      setSelectedZone("");
+      setFieldItems([]);
+      setHiddenItems([]);
+      setShopItems([]);
+      setScriptItems([]);
+      setFixedShops([]);
+      setHeartScaleShop([]);
     }
+  };
 
-    //Draw the rectangle
-    ctx.fillStyle = modeMap[mode];
-    ctx.fillRect(x, y, width, height);
-  }
-
-  function clearRect(mode=CLEAR_MODE.HIGHLIGHT, encLocation) { // coords defined for Encounters
-    //Clears the old location and restores the image data at that position.
-    const ctx = canvasRef.current.getContext('2d', {willReadFrequently: true});
-    if (mode !== CLEAR_MODE.ENCOUNTER) {
-      const {x, y, width, height} = previousRectangle[mode];
-      ctx.clearRect(x, y, width, height);
-      if (mode === CLEAR_MODE.SELECT) {
-        // This adds a hierarchy of which highlights override others
-        // In order to do this, it will first clear the lower mode's rect
-        // Then it will set that lower mode's rect to null
-        // This way it won't clear the higher mode's rect when the lower mode is called again
-        // The hierarchy will be 1: Select, 2: Highlight, 3: Encounter.
-
-        if (previousRectangle.highlight !== null) {
-          clearRect(CLEAR_MODE.HIGHLIGHT);
-          previousRectangle.highlight = null;
-        }
-      }
-      ctx.putImageData(originalImageData[mode], x, y);
-    } else {
-      const { x, y, width, height } = encLocation;
-      const location = getSelectedLocation(x, y);
-      if (!location) {
-        throw new Error("Try again with your location bozo :P");
-      }
-      const { zoneId } = location;
-      const prevRectangleDataIndex = previousRectangle.enc.findIndex((rect) =>
-        isLocationExactlyEqual(rect, encLocation)
-      );
-      const ogImageData = originalImageData.enc[prevRectangleDataIndex];
-      if (zoneId !== locationId.current) {
-        ctx.clearRect(x, y, width, height);
-        ctx.putImageData(ogImageData, x, y);
-      } else {
-        ctx.clearRect(x, y, width, height);
-        ctx.putImageData(ogImageData, x, y);
-        drawRect(encLocation, CLEAR_MODE.SELECT);
-      }
-    }
-  }
+  const handleSetLocationZoneId = (zoneId) => {
+    const newZoneId = zoneId ?? null;
+    setSelectedLocation(newZoneId);
+    locationId.current = newZoneId;
+    setTrainerList(getTrainersFromZoneId(newZoneId));
+    setEncounterList(setAllEncounters(newZoneId) || []);
+    setFieldItems(getFieldItemsFromZoneID(newZoneId));
+    setHiddenItems(getHiddenItemsFromZoneID(newZoneId));
+    setShopItems(getRegularShopItems(newZoneId));
+    setScriptItems(getScriptItems(newZoneId));
+    setFixedShops(getFixedShops(newZoneId));
+    setHeartScaleShop(getHeartScaleShopItems(newZoneId));
+  };
 
   return (
     <div className="mapper">
@@ -686,13 +273,42 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
         className="canvasCol"
         style={{gridTemplate: `${canvasDimensions.height}px / ${canvasDimensions.width}px auto`}}
       >
-        <canvas
-          ref={canvasRef}
-          height={`${canvasDimensions.height}px`}
-          width={`${canvasDimensions.width}px`}
+        <Canvas
+          width={canvasDimensions.width}
+          height={canvasDimensions.height}
+          onMouseMove={handleNewMouseMove}
+          onMouseUp={handleMouseUpClick}
+          captureAllKeyEvents={false}
         >
-          Your browser does not support the canvas element.
-        </canvas>
+          <Image
+            x={0}
+            y={0}
+            width={canvasDimensions.width}
+            height={canvasDimensions.height}
+            src={mapperImage}
+          />
+          {sortedCoordinates.map((location, locationIndex) => (
+            <>
+              <Location
+                key={`${location.zoneId}-${locationIndex}`}
+                location={location}
+                mouseCoords={mouseCoords}
+                selectedLocation={selectedLocation}
+                encounterLocations={encounterLocations}
+                colors={colors}
+              />
+              <Rect
+                key={`outline-${location.zoneId}-${locationIndex}`}
+                x={location.x}
+                y={location.y}
+                x2={location.x + location.width}
+                y2={location.y + location.height}
+                color={"#000"}
+                fill={false}
+              />
+            </>
+          ))}
+        </Canvas>
         <MapperTabPanel
           encOptions={encOptions}
           handleOptionChange={handleOptionChange}
@@ -703,18 +319,16 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
           selectedTrainer={selectedTrainer}
           setSelectedTrainer={setSelectedTrainer}
           openTrainerModal={openTrainerModal}
-          routeId={selectedZoneId}
+          routeId={selectedLocation}
         />
       </div>
       <SearchBar
         canvasDimensions={canvasDimensions}
         pokemonList={pokemonList}
-        debouncedText={pokemonName}
         handleDebouncedTextChange={handlePokemonNameChange}
         locationName={selectedZone}
         setLocationName={setSelectedZone}
-        setLocationZoneId={setSelectedZoneId}
-        canvasRef={canvasRef.current}
+        setLocationZoneId={handleSetLocationZoneId}
         selectedPokemon={selectedPokemon}
         setSelectedPokemon={setSelectedPokemon}
         handleShowSettings={handleShowSettings}
@@ -802,7 +416,6 @@ export const Mapper = ({ pokemonList3, pokemonList, pokemonListV }) => {
         setColors={setColors}
         showModal={showSettings}
         onHide={handleCloseSettings}
-        canvasRef={canvasRef.current}
       />
     </div>
   );

--- a/src/components/Mapper/SearchBar.jsx
+++ b/src/components/Mapper/SearchBar.jsx
@@ -9,60 +9,50 @@ import './style.css';
 
 const PokemonSearchInput = ({
   allPokemons,
-  debouncedText,
   setDebouncedText,
-  canvasRef,
   selectedPokemon,
   setSelectedPokemon,
 }) => {
-  // It appears the original intent was to debounce a search text input, so we will manage that text with `searchText` and `debouncedText`.
-  const [searchText, setSearchText] = useState('');
+  const [searchText, setSearchText] = useState("");
 
-  // Fuse setup should be moved inside a useEffect to avoid initializing it on every render.
-  useEffect(() => {
-    const fuse = new Fuse(allPokemons, { keys: ['monsno', 'name'] });
-    // Ideally, use fuse to filter/search through `allPokemons` based on `debouncedText`.
-    // For now, this isn't directly used, but can be integrated for actual search functionality.
-  }, [allPokemons]);
-
-  // Debouncing effect for searchText.
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedText(searchText);
-    }, 300); // 300ms is a common choice for debouncing.
+    }, 300);
     return () => clearTimeout(timer);
-  }, [searchText]);
+  }, [searchText, setDebouncedText]);
 
-  const handlePokemonNameChange = (event, value) => {
-    // Dispatch event with the name of the selected Pokemon.
-    const pokemonLocationsEvent = new CustomEvent('passPokemonNameLocation', { detail: value });
-    canvasRef.dispatchEvent(pokemonLocationsEvent);
-    // Assume `value` is the whole Pokemon object selected from options.
-    setSelectedPokemon(value);
-    // Set the searchText as the Pokemon's name, which will then be debounced.
-    setSearchText(value.name);
+  const handlePokemonNameChange = (_, value, reason) => {
+    if (reason !== "clear" && value) {
+      setSelectedPokemon(value);
+      setSearchText(value?.name ?? "");
+    } else {
+      setSelectedPokemon(null);
+      setSearchText("");
+    }
   };
 
-  const handleInputChange = (event) => {
-    // Update searchText directly from input.
-    setSearchText(event.target.value);
+  const handleInputChange = (_, value) => {
+    setSearchText(value);
   };
 
   return (
     <div className="monSearchBar">
       <Autocomplete
         id="pokemon-search-input"
+        clearOnBlur={false}
+        blurOnSelect
         options={allPokemons}
         getOptionLabel={(option) => option.name}
         value={selectedPokemon}
         onChange={handlePokemonNameChange}
+        inputValue={searchText}
+        onInputChange={handleInputChange}
         renderInput={(params) => (
           <TextField
             {...params}
             label="Search Pokémon Location"
             fullWidth
-            onChange={handleInputChange}
-            value={searchText} // Use searchText to reflect input changes immediately
           />
         )}
       />
@@ -77,12 +67,15 @@ const LocationNameDropdown = ({
   canvasRef
 }) => {
   const locations = getLocationNames();
-  const handleLocationChange = (e, value) => {
-    const locationNameEvent = new CustomEvent('passLocationNameToParent', { detail: value });
-    canvasRef.dispatchEvent(locationNameEvent);
-    setLocationName(value);
-    const { zoneId } = getLocationCoordsFromName(value);
-    setLocationZoneId(zoneId);
+  const handleLocationChange = (e, value, reason) => {
+    if (reason !== "clear" && value) {
+      setLocationName(value);
+      const location = getLocationCoordsFromName(value);
+      setLocationZoneId(location?.zoneId);
+    } else {
+      setLocationName(null);
+      setLocationZoneId(null);
+    }
   };
 
   const defaultOption = locations.length > 0 ? locations[0] : '';
@@ -90,18 +83,21 @@ const LocationNameDropdown = ({
     <div className="location">
       <Autocomplete
         id="location-input"
+        clearOnBlur={false}
+        blurOnSelect
         options={locations}
         getOptionLabel={(option) => option}
-        defaultValue={defaultOption}
         value={locationName}
         onChange={handleLocationChange}
+        inputValue={locationName ?? ""}
+        onInputChange={(_, value) => {
+          setLocationName(value);
+        }}
         renderInput={(params) => (
           <TextField
             {...params}
             label="Current Location"
             fullWidth
-            value={locationName}
-            onChange={(e) => setLocationName(e.target.value)}
           />
         )}
       />
@@ -122,7 +118,6 @@ const SettingsButton = ({handleShowSettings}) => {
 export const SearchBar = ({
   canvasDimensions,
   pokemonList,
-  debouncedText,
   handleDebouncedTextChange,
   locationName,
   setLocationName,
@@ -142,9 +137,7 @@ export const SearchBar = ({
     >
       <PokemonSearchInput
         allPokemons={pokemonList}
-        debouncedText={debouncedText}
         setDebouncedText={handleDebouncedTextChange}
-        canvasRef={canvasRef}
         selectedPokemon={selectedPokemon}
         setSelectedPokemon={setSelectedPokemon}
       />
@@ -152,7 +145,6 @@ export const SearchBar = ({
         locationName={locationName}
         setLocationName={setLocationName}
         setLocationZoneId={setLocationZoneId}
-        canvasRef={canvasRef}
       />
       <SettingsButton handleShowSettings={handleShowSettings} />
     </div>

--- a/src/components/Mapper/Settings/HighlightColors.jsx
+++ b/src/components/Mapper/Settings/HighlightColors.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TextField, Typography, Button, Grid2 } from '@mui/material';
 import '../style.css';
+import { NumberField } from '@base-ui/react';
 
 const INPUT_MIN = 0;
 const TRANSPARENCY_MAX = 1;

--- a/src/components/Mapper/Settings/HighlightColors.jsx
+++ b/src/components/Mapper/Settings/HighlightColors.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { TextField, Typography, Grid, Button } from '@mui/material';
+import { TextField, Typography, Button, Grid2 } from '@mui/material';
 import '../style.css';
 
-const INPUT_MIN = "0";
-const TRANSPARENCY_MAX = "1";
-const TRANSPARENCY_STEP = ".1";
-const COLOR_MAX = "255";
-const COLOR_STEP = "1";
+const INPUT_MIN = 0;
+const TRANSPARENCY_MAX = 1;
+const TRANSPARENCY_STEP = 0.1;
+const COLOR_MAX = 255;
+const COLOR_STEP = 1;
 
 export const ChangeHighlightColors = ({
   colorKeys,
@@ -18,43 +18,60 @@ export const ChangeHighlightColors = ({
   return (
     <form onSubmit={handleSubmit} noValidate>
       <Typography variant='h6' style={{ marginTop: '16px' }}>Change Highlight Colors</Typography>
-      <Grid container spacing={3} sx={{marginTop: "0px"}}>
+      <Grid2 container spacing={3} sx={{marginTop: "0px"}}>
         {colorKeys.map((colorKey) => (
-          <Grid item xs={12} sm={4} key={colorKey} sx={{paddingTop: "8px !important"}}>
-            <Typography variant="subtitle1">
-              {`${colorKey.toUpperCase()} Color`}
-            </Typography>
-            <div
-              style={{
-                width: '20px',
-                height: '20px',
-                marginLeft: '8px',
-                backgroundColor: `rgba(${newColors[colorKey].r},${newColors[colorKey].g},${newColors[colorKey].b},${newColors[colorKey].a})`,
-                border: '1px solid #fff',
-              }}
-            />
-            {Object.keys(newColors[colorKey]).map((subKey) => (
-              <div key={subKey} style={{ marginTop: '8px' }}>
-                <TextField
-                  label={subKey === 'a' ? `${subKey.toUpperCase()} (Coming Soon)` : subKey.toUpperCase()}
-                  name={`${colorKey}-${subKey}`}
-                  type="number"
-                  variant="outlined"
-                  size="small"
-                  inputProps={{
-                    min: INPUT_MIN,
-                    max: subKey === 'a' ? TRANSPARENCY_MAX : COLOR_MAX,
-                    step: subKey === 'a' ? TRANSPARENCY_STEP : COLOR_STEP,
-                  }}
-                  value={newColors[colorKey][subKey]}
-                  onChange={(e) => handleChange(colorKey, subKey, e.target.value)}
-                  disabled={subKey === 'a'}
-                />
-              </div>
-            ))}
-          </Grid>
+          colorKey !== "default" && (
+            <Grid2 item xs={12} sm={4} key={colorKey} sx={{paddingTop: "8px !important"}}>
+              <Typography variant="subtitle1">
+                {`${colorKey.toUpperCase()} Color`}
+              </Typography>
+              <div
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  marginLeft: '8px',
+                  backgroundColor: `rgba(${newColors[colorKey].r},${newColors[colorKey].g},${newColors[colorKey].b},${newColors[colorKey].a})`,
+                  border: '1px solid #fff',
+                }}
+              />
+              {Object.keys(newColors[colorKey]).map((subKey) => {
+                const id = React.useId();
+                return (
+                  <div key={subKey} style={{ marginTop: '8px' }}>
+                    <NumberField.Root
+                      step={subKey === 'a' ? TRANSPARENCY_STEP : COLOR_STEP}
+                      min={INPUT_MIN}
+                      max={subKey === 'a' ? TRANSPARENCY_MAX : COLOR_MAX}
+                      id={id}
+                      value={newColors[colorKey][subKey]}
+                      defaultValue={100}
+                      onValueChange={(value, e) => handleChange(colorKey, subKey, value)}
+                    >
+                      <NumberField.ScrubArea>
+                        <NumberField.ScrubAreaCursor>
+                          <CursorGrowIcon />
+                        </NumberField.ScrubAreaCursor>
+                        <label htmlFor={id} className='ScrubLabel'>
+                          {`${subKey.toUpperCase()} Value`}
+                        </label>
+                      </NumberField.ScrubArea>
+                      <NumberField.Group>
+                        <NumberField.Decrement>
+                          <MinusIcon />
+                        </NumberField.Decrement>
+                        <NumberField.Input />
+                        <NumberField.Increment>
+                          <PlusIcon />
+                        </NumberField.Increment>
+                      </NumberField.Group>
+                    </NumberField.Root>
+                  </div>
+                );
+              })}
+            </Grid2>
+          )
         ))}
-      </Grid>
+      </Grid2>
       <div style={{ marginTop: '16px', display: 'flex', justifyContent: 'center' }}>
           <Button variant="contained" color="secondary" type="submit">
             Save Changes
@@ -67,3 +84,52 @@ export const ChangeHighlightColors = ({
   );
 }
 
+function CursorGrowIcon(props) {
+  return (
+    <svg
+      width="26"
+      height="14"
+      viewBox="0 0 24 14"
+      fill="black"
+      stroke="white"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M19.5 5.5L6.49737 5.51844V2L1 6.9999L6.5 12L6.49737 8.5L19.5 8.5V12L25 6.9999L19.5 2V5.5Z" />
+    </svg>
+  );
+}
+
+function PlusIcon(props) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentcolor"
+      strokeWidth="1.6"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M0 5H5M10 5H5M5 5V0M5 5V10" />
+    </svg>
+  );
+}
+
+function MinusIcon(props) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentcolor"
+      strokeWidth="1.6"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M0 5H10" />
+    </svg>
+  );
+}

--- a/src/components/Mapper/Settings/SettingsModal.jsx
+++ b/src/components/Mapper/Settings/SettingsModal.jsx
@@ -3,7 +3,7 @@ import { Modal, Button, Typography, Box } from '@mui/material';
 import '../style.css';
 import { ChangeHighlightColors } from './HighlightColors';
 
-const SettingsModal = ({ colors, setColors, showModal, onHide, canvasRef }) => {
+const SettingsModal = ({ colors, setColors, showModal, onHide }) => {
   const [newColors, setNewColors] = useState(colors);
 
   const handleChange = (colorKey, subKey, value) => {
@@ -11,7 +11,7 @@ const SettingsModal = ({ colors, setColors, showModal, onHide, canvasRef }) => {
       ...newColors,
       [colorKey]: {
         ...newColors[colorKey],
-        [subKey]: parseInt(value),
+        [subKey]: value,
       },
     });
   };
@@ -27,20 +27,13 @@ const SettingsModal = ({ colors, setColors, showModal, onHide, canvasRef }) => {
       }
       updatedColors[colorKey][subKey] = value;
     }
-    updatedColors.hov.a = 0.7;
-    updatedColors.sel.a = 0.7;
-    updatedColors.enc.a = 0.7;
     setColors(newColors);
-    const colorSettingsEvent = new CustomEvent('changeColorSettings', { detail: updatedColors });
-    canvasRef.dispatchEvent(colorSettingsEvent);
     onHide();
   };
 
   const handleNoSaveClose = () => {
     setColors(colors);
     onHide();
-    const colorSettingsEvent = new CustomEvent('changeColorSettings', { detail: colors });
-    canvasRef.dispatchEvent(colorSettingsEvent);
   };
 
   const colorKeys = Object.keys(newColors);

--- a/src/components/Mapper/Settings/SettingsModal.jsx
+++ b/src/components/Mapper/Settings/SettingsModal.jsx
@@ -17,7 +17,6 @@ const SettingsModal = ({ colors, setColors, showModal, onHide }) => {
   };
 
   const handleSubmit = (event) => {
-    event.preventDefault();
     const formData = new FormData(event.target);
     const updatedColors = {};
     for (let [key, value] of formData.entries()) {

--- a/src/components/Mapper/TabPanel/EncountersPanel.jsx
+++ b/src/components/Mapper/TabPanel/EncountersPanel.jsx
@@ -63,6 +63,7 @@ const EncountersPanel = ({ encOptions, handleOptionChange, encounterList, pokemo
               />
             }
             label={option.charAt(0).toUpperCase() + option.slice(1)}
+            disabled={option === "radar" && (caveIds.includes(routeId) || groundEncountersIds.includes(routeId))}
           />
         ))}
       </Box>

--- a/src/components/Mapper/coordinates.js
+++ b/src/components/Mapper/coordinates.js
@@ -1,10 +1,33 @@
 import MapperCoordinates from './coordinates.json';
 
+function sortByXThenYDescending(arr) {
+    const seen = new Set();
+    const unique = [];
+
+    for (const item of arr) {
+        const key = `${item.x},${item.y}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            unique.push(item);
+        }
+    }
+
+    return unique.sort((a, b) => {
+        if (b.x !== a.x) return b.x - a.x;
+        return b.y + a.y;
+    });
+}
+
+export const sortedCoordinates = sortByXThenYDescending(MapperCoordinates);
+
 export const getLocationNames = () => {
     return MapperCoordinates.map(coord => coord.name);
 };
 
 export function getLocationCoordsFromName(name) {
+    if (!name) {
+        return null;
+    }
     return MapperCoordinates.find(coord => coord.name === name);
 };
 
@@ -12,17 +35,17 @@ export function getLocationCoordsFromZoneId(zoneId) {
     return MapperCoordinates.find(coord => coord.zoneId === zoneId);
 };
 
+const isXWithinBounds = (coords, x) => {
+    const isWithinX = coords.x <= x && x <= coords.x + coords.width;
+    return isWithinX;
+};
+
+const isYWithinBounds = (coords, y) => {
+    const isWithinY = coords.y <= y && y <= coords.y + coords.height;
+    return isWithinY;
+};
+
 export function getSelectedLocation(x, y) {
-    const isXWithinBounds = (coords, x) => {
-        const isWithinX = coords.x <= x && x <= coords.x + coords.width;
-        return isWithinX;
-    };
-
-    const isYWithinBounds = (coords, y) => {
-        const isWithinY = coords.y <= y && y <= coords.y + coords.height;
-        return isWithinY;
-    };
-
     let selectedLocation = null;
 
     for (let i = 0; i < MapperCoordinates.length; i++) {
@@ -48,5 +71,13 @@ export function isLocationExactlyEqual(location, comparedLocation) {
       comparedLocation.height === height
     )
 }
+
+export function isLocationWithinBounds (location, mouseCoords) {
+    const { x, y } = mouseCoords;
+    const xWithinBounds = isXWithinBounds(location, x);
+    const yWithinBounds = isYWithinBounds(location, y);
+
+    return xWithinBounds && yWithinBounds;
+};
 
 export { MapperCoordinates };

--- a/src/components/Mapper/coordinates.json
+++ b/src/components/Mapper/coordinates.json
@@ -10,7 +10,7 @@
   {
       "x": 372,
       "y": 570,
-      "width": 32,
+      "width": 33,
       "height": 36,
       "name": "Route 202",
       "zoneId": 355
@@ -18,7 +18,7 @@
   {
       "x": 372,
       "y": 606,
-      "width": 32,
+      "width": 33,
       "height": 32,
       "name": "Sandgem Town",
       "zoneId": 429
@@ -37,7 +37,7 @@
       "width": 35,
       "height": 34,
       "name": "Lake Verity Cavern",
-      "zoneId": 326
+      "zoneId": 325
   },
   {
       "x": 787,
@@ -379,7 +379,7 @@
       "x": 493,
       "y": 322,
       "width": 33,
-      "height": 174,
+      "height": 172,
       "name": "Route 206",
       "zoneId": 362
   },
@@ -401,9 +401,9 @@
   },
   {
       "x": 493,
-      "y": 496,
+      "y": 494,
       "width": 78,
-      "height": 33,
+      "height": 34,
       "name": "Route 207",
       "zoneId": 364
   },
@@ -433,9 +433,9 @@
   },
   {
       "x": 483,
-      "y": 529,
+      "y": 528,
       "width": 53,
-      "height": 51,
+      "height": 52,
       "name": "Oreburgh City",
       "zoneId": 38
   },
@@ -482,7 +482,7 @@
   {
       "x": 372,
       "y": 638,
-      "width": 32,
+      "width": 33,
       "height": 33,
       "name": "Route 219",
       "zoneId": 403
@@ -1064,10 +1064,10 @@
       "zoneId": 285
   },
   {
-      "x": 775,
+      "x": 774,
       "y": 173,
-      "width": 51,
-      "height": 52,
+      "width": 53,
+      "height": 54,
       "name": "Battle Tower",
       "zoneId": 336
   },
@@ -1075,7 +1075,7 @@
       "x": 721,
       "y": 228,
       "width": 52,
-      "height": 51,
+      "height": 52,
       "name": "Fight Area",
       "zoneId": 186
   },

--- a/src/components/Mapper/style.css
+++ b/src/components/Mapper/style.css
@@ -145,3 +145,9 @@
     max-height: 80%;
     max-width: 1200px;
 }
+
+.ScrubLabel {
+    cursor: ew-resize;
+    font-weight: bold;
+    user-select: none;
+}

--- a/src/components/Mapper/style.css
+++ b/src/components/Mapper/style.css
@@ -57,17 +57,18 @@
     display: grid;
     grid-template-rows: 60px 25px;
     pointer-events: none;
+    touch-action: manipulation;
 }
 
 .monSearchBar {
-    pointer-events: all;
+    pointer-events: auto;
     width: 300px;
     margin-top: 10px;
     margin-right: 10px;
 }
 
 .location {
-    pointer-events: all;
+    pointer-events: auto;
     margin-top: 16px;
     margin-right: 10px;
 }
@@ -80,7 +81,7 @@
     height: fit-content;
     margin-left: 16rem;
     margin-top: 36rem;
-    pointer-events: all;
+    pointer-events: auto;
 }
 
 .stats {

--- a/src/components/Pokedex/PokemonSearch.jsx
+++ b/src/components/Pokedex/PokemonSearch.jsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import { getPokemonNames, getPokemonIdFromName } from '../../utils/dex';
 import { MAX_CURRENT_POKEMON } from '../Pokedex2/pokedexConstants';
 
 export const PokemonSearch = ({ setPokemonDexId }) => {
   // pokemonNameEndRange number is not including
-  const pokemonNames = getPokemonNames(MAX_CURRENT_POKEMON + 1);
+  const pokemonNames = useMemo(() => getPokemonNames(MAX_CURRENT_POKEMON + 1), []);
   const [selectedPokemonName, setSelectedPokemonName] = useState(pokemonNames[1]);
   const [inputValue, setInputValue] = React.useState('');
 

--- a/src/components/Pokedex2/EvolutionGraph.jsx
+++ b/src/components/Pokedex2/EvolutionGraph.jsx
@@ -50,7 +50,7 @@ export default function EvolutionGraph({ evolutionTree }) {
       <div className="row" style={{ margin: 'auto', textAlign: 'center' }}>
         <span className="col col-12">
           <Typography variant="h6" sx={{ margin: 'auto' }}>
-            <a href='https://luminescent.team/docs/special-evolutions#alcremie'>Alcremie Evolutions</a>
+            <Link href='https://luminescent.team/docs/special-evolutions#alcremie'>Alcremie Evolutions</Link>
           </Typography>
         </span>
       </div>

--- a/src/pages/_mapper.jsx
+++ b/src/pages/_mapper.jsx
@@ -5,6 +5,10 @@ import { GlobalState } from '../components/common/GlobalState';
 import LumiReactThemeProvider from '../theme/LumiThemeProvider';
 
 const MapperPage = ({ pokemonList, pokemonListV, pokemonList3 }) => {
+  // required for webpack SSR
+  if (typeof pokemonList === 'undefined') {
+    return null;
+  }
   return (
     <Layout>
       <LumiReactThemeProvider>
@@ -13,7 +17,7 @@ const MapperPage = ({ pokemonList, pokemonListV, pokemonList3 }) => {
         </GlobalState>
       </LumiReactThemeProvider>
     </Layout>
-  )
-}
+  );
+};
 
 export default MapperPage;

--- a/src/pages/_mapper.jsx
+++ b/src/pages/_mapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import { Mapper } from '../components/Mapper/Mapper';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import { GlobalState } from '../components/common/GlobalState';
 import LumiReactThemeProvider from '../theme/LumiThemeProvider';
 
@@ -13,7 +13,12 @@ const MapperPage = ({ pokemonList, pokemonListV, pokemonList3 }) => {
     <Layout>
       <LumiReactThemeProvider>
         <GlobalState>
-          <Mapper pokemonList={pokemonList} pokemonList3={pokemonList3} pokemonListV={pokemonListV} />
+          <BrowserOnly fallback={<div>Loading mapper...</div>}>
+            {() => {
+              const { Mapper } = require('../components/Mapper/Mapper');
+              return <Mapper pokemonList={pokemonList} pokemonList3={pokemonList3} pokemonListV={pokemonListV} />;
+            }}
+          </BrowserOnly>
         </GlobalState>
       </LumiReactThemeProvider>
     </Layout>

--- a/src/utils/dex/encounters.js
+++ b/src/utils/dex/encounters.js
@@ -293,6 +293,9 @@ function getEventEncounters(areaEncounters) {
 };
 
 function getMapperRoutesFromPokemonId(pokemonId, mode = GAMEDATA2) {
+  if (!pokemonId) {
+    return [];
+  }
   const routeNames = [];
   const ModePokemonLocations = PokemonLocations[mode];
   const ModeStaticLocations = StaticLocations[mode];

--- a/src/utils/dex/item.js
+++ b/src/utils/dex/item.js
@@ -43,27 +43,35 @@ function getBattleItemPrice(itemId = 0, mode = GAMEDATA2) {
   return ModeItemTable.Item[itemId].bp_price;
 }
 
-function getRegularShopItems(zoneId) {
+function getRegularShopItems(zoneId, mode = GAMEDATA2) {
+  const modeShopTable = ShopTable[mode];
   const excludedZones = [473, 456, 422];
   const zoneCode = getZoneCodeFromCSV(zoneId + 1);
+  if (!zoneCode) {
+    return [];
+  }
   if (
     zoneCode.startsWith("C") ||
     (zoneCode.startsWith("T") && !excludedZones.includes(zoneId))
     ) {
-    const shopItems = ShopTable.FS.filter(obj => obj.ZoneID === zoneId || obj.ZoneID === -1);
+    const shopItems = modeShopTable.FS.filter(obj => obj.ZoneID === zoneId || obj.ZoneID === -1);
     return shopItems;
   }
   return null;
 }
 
-function getScriptItems(zoneId) {
+function getScriptItems(zoneId, mode=GAMEDATA2) {
+  const modeItemMap = ItemMap[mode];
   const zoneCode = getZoneCodeFromCSV(zoneId);
+  if (!zoneCode) {
+    return [];
+  }
   const lookup = zoneCode.slice(0, 3).toLowerCase();
   const result = [];
 
-  Object.keys(ItemMap).forEach(key => {
+  Object.keys(modeItemMap).forEach(key => {
     if (key.startsWith(lookup)) {
-      const flattenedArray = ItemMap[key].flat(Infinity);
+      const flattenedArray = modeItemMap[key].flat(Infinity);
       const uniqueArray = [...new Set(flattenedArray)];
       result.push(...uniqueArray);
     }
@@ -72,19 +80,23 @@ function getScriptItems(zoneId) {
   return result;
 }
 
-function getFixedShops(zoneId) {
+function getFixedShops(zoneId, mode=GAMEDATA2) {
+  const modeFixedShop = FixedShop[mode];
   const zoneCode = getZoneCodeFromCSV(zoneId);
+  if (!zoneCode) {
+    return null;
+  }
   const lookup = zoneCode.slice(0, 3).toLowerCase();
   const groupedData = {};
 
-  Object.keys(FixedShop).forEach(key => {
+  Object.keys(modeFixedShop).forEach(key => {
     const prefix = key.slice(0, 3);
     
     if (!groupedData[prefix]) {
       groupedData[prefix] = {};
     }
   
-    groupedData[prefix][key] = FixedShop[key];
+    groupedData[prefix][key] = modeFixedShop[key];
   });
 
   const filteredData = groupedData[lookup] || {}

--- a/src/utils/dex/trainers.js
+++ b/src/utils/dex/trainers.js
@@ -4,7 +4,10 @@ function getTrainersFromZoneId(zoneId, mode = GAMEDATA2) {
   if (zoneId === null) {
     return [];
   }
-  const zoneKey = zoneId.toString();
+  let zoneKey = zoneId.toString();
+  if (zoneKey === "327") { // Put the Lake Valor Before trainers
+    zoneKey = "326" // To be at the Lake Valor After for ease of use.
+  }
   if (zoneKey in TrainerLocations[mode]) {
     return TrainerLocations[mode][zoneKey];
   }


### PR DESCRIPTION
## New Features
- Uses the new [React-Canvas](https://github.com/Bucky24/react-canvas/tree/master) npm package to make the drawing algorithm much better
- Shows the name of locations when you hover over it
- Made the Pokemon names clickable links in the Encounter Lists
- Disabled Radar selection in caves and indoors
- Added the ability to change the transparency of the Highlight Colors in the Settings menu

## Bug Fixes
- Known Bug # 1 is fixed. If you refresh the page and your cursor is hovering over a route, it will NO LONGER delete the image and show a blank space where that route should be
- Known Bug # 2 is fixed. Misaligned cursors will no longer be a problem with the new React-Canvas package
- Known Bug # 3 is fixed. The Encounter methods will carry over to the new selected route.
- Known Bug # 4 is fixed. Alt forms all have unique names now and you'll be able to search them independently. This was fixed in an earlier update, but confirmed here.
- Known Bug # 5 is fixed. The encounter highlight will persist regardless of whether it was the first selected area.
- Window can be any size you want now
- Fixed a bug that caused double highlights when selecting pokemon that both show up in the same place
- Fixed missing trainers at Lake Valor
- Removed trainers from Lake Verity Cavern
- Updated the docs to have better syntax
