### PR TITLE
Update compatible mods

### DIFF
--- a/docs/installation/atmosphere.mdx
+++ b/docs/installation/atmosphere.mdx
@@ -8,7 +8,8 @@ description: Guide for native Switch hardware using CFW Atmosphere.
 
 :::caution
 
-Do not install any other mods with Luminescent Platinum! You will risk breaking your game!
+Do not install any other mods that don't explicitly mention compatibility with Luminescent Platinum! You will risk breaking your game!\
+You can find a list of compatible mods in our [Compatible Mods List](/mods.mdx), or on [Nexus Mods](https://www.nexusmods.com/games/pokemonbdsp).
 
 :::
 

--- a/docs/installation/ryujinx.mdx
+++ b/docs/installation/ryujinx.mdx
@@ -8,7 +8,8 @@ description: Guide for installing Luminescent Platinum for Ryujinx emulator. Rec
 
 :::caution
 
-Do not install any other mods with Luminescent Platinum! You will risk breaking your game!
+Do not install any other mods that don't explicitly mention compatibility with Luminescent Platinum! You will risk breaking your game!\
+You can find a list of compatible mods in our [Compatible Mods List](/mods.mdx), or on [Nexus Mods](https://www.nexusmods.com/games/pokemonbdsp).
 
 :::
 

--- a/docs/mods.mdx
+++ b/docs/mods.mdx
@@ -65,10 +65,15 @@ These Overhaul mods aim to change large aspects of the game. Some of these may h
 
 These mods are translation patches for Luminescent Platinum into other languages. Please note that they are fan translations and we cannot vouch for their content, quality or accuracy.
 
+:::info
+Translation patches that have not been updated to 2.2F will still work just fine, only a couple of minor strings were changed.
+
+:::
+
 | Translation Mods                                                                    | Author                  | Notes                     |
 | ----------------------------------------------------------------------------------- | ----------------------- | ------------------------- |
-| [Luminescent Platinum GERMAN Translation Patch - Luminoeses Platin](https://www.nexusmods.com/pokemonbdsp/mods/23)                     | Team Deudle             | 2.1F (compatible with 2.2F)                     | German Translation np|
+| [Luminescent Platinum GERMAN Translation Patch - Luminoeses Platin](https://www.nexusmods.com/pokemonbdsp/mods/23)                     | Team Deudle             | 2.1F                     | German Translation np|
 | [Luminescent Platinum Korean Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/31)                     | Yurical              | 2.2F                      | Korean Translation np|
 | [Luminescent Platinum Spanish (Spain) Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/49)                     | Chaotic Spaniards               | 2.2F                      | Spanish Translation np|
-| [Luminescent Platinum Traditional Chinese Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/37)                     | FrozenZero              | 2.1F (compatible with 2.2F)                     | Traditional Chinese Translation np|
-| [Luminescent Platinum French Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/44)                     | Team French              | 2.1F (compatible with 2.2F)                     | French Translation np|
+| [Luminescent Platinum Traditional Chinese Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/37)                     | FrozenZero              | 2.1F                    | Traditional Chinese Translation np|
+| [Luminescent Platinum French Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/44)                     | Team French              | 2.1F                     | French Translation np|

--- a/docs/mods.mdx
+++ b/docs/mods.mdx
@@ -21,26 +21,36 @@ The following mods are already packaged in. To see what other features we includ
 
 # Compatible Mods
 
-The following mods are optional, but compatible, with Luminescent Platinum as verified by our dev team. Please always be aware of what version of Luminescent you are running before adding a mod, and remember to mention these additions if you need help troubleshooting in our Discord.
+The following mods are optional, but compatible, with Luminescent Platinum as verified by our dev team. Please always be aware of what version of Luminescent you are running before adding a mod, and remember to mention these additions if you need help troubleshooting in our Discord.\
+New mods release often, if you want to make sure you are not missing anything, you can also check [Nexus Mods](https://www.nexusmods.com/games/pokemonbdsp) directly.
 
 | Compatible Mods                                                                     | Author                  | Lumi Version              | Notes                     |
 | ----------------------------------------------------------------------------------- | ----------------------- | ------------------------- | ------------------------- |
+| [Pokemon Dechibified Platinum](https://www.nexusmods.com/pokemonbdsp/mods/38)                     | Adomin8er                | 2.2F                      | 	Has versions for vanilla, Lumi, and Coronet.|
 | [60fps and Speedup](https://www.nexusmods.com/pokemonbdsp/mods/9)                   | ProfBlack               | 2.2F                      | Can adjust Lumi to 30fps, 1x speed or 3x speed, etc..|
+| [Lumi Resaturated](https://www.nexusmods.com/pokemonbdsp/mods/39)                   | SneezyWeavile               | 2.2F                      |                           |
+| [Increased Shiny Odds](https://www.nexusmods.com/pokemonbdsp/mods/59)                   | Blup               | 2.2F                      |                           |
 | [Colorful Bikeinator](https://www.nexusmods.com/pokemonbdsp/mods/7)                 | Leoparodo               | 2.2F                      |                           |
-| [Darker UI Lumi](https://www.nexusmods.com/pokemonbdsp/mods/12)                     | faospark                | 2.1F                      | Contains different add-ons for preferences.|
+| [Darker UI Lumi](https://www.nexusmods.com/pokemonbdsp/mods/12)                     | faospark                | 2.2F                      | Contains different add-ons for preferences.|
 | [Easier Underground Digging](https://gamebanana.com/mods/340161)                    | Edgarska                | 2.0F                      |                           |
 | [Eevee Hoodie Style](https://gamebanana.com/mods/339850)                            | A Lime                  | 2.2F                      |                           |
 | [EVless Patch](https://www.nexusmods.com/pokemonbdsp/mods/17)                       | DJ                      | 2.2F                      | Has both a vanilla and Lumi version.                         |
 | [Hisui Pokeballs](https://www.nexusmods.com/pokemonbdsp/mods/14)                    | ProfBlack               | 2.2F                      |                           |
 | [Luminescent Platinum name and icon](https://www.nexusmods.com/pokemonbdsp/mods/5)  | FlavvArouf              | 2.2F                      | Only works on hardware.   |
 | [No Bike Outfit](https://www.nexusmods.com/pokemonbdsp/mods/25)                     | DJ                      | 2.2F                      |                           |
-| [Original Base Stats for Luminescent Platinum](https://www.nexusmods.com/pokemonbdsp/mods/48/) | ClemiNeko  | 2.1F                      | Option for base stats and for typings.|
-| [Original Typings for Luminescent Platinum](https://www.nexusmods.com/pokemonbdsp/mods/40/) | PraiseThyJeebus | 2.1F                      | Only adjusts typings, not movepool or BST. |
+| [Original Base Stats for Luminescent Platinum](https://www.nexusmods.com/pokemonbdsp/mods/48/) | ClemiNeko  | 2.2F                      | Option for base stats, typings and learnsets.|
 | [Playstation Button Swap](https://www.nexusmods.com/pokemonbdsp/mods/8)             | Leoparodo               | 2.1F                      |                           |
-| [Pokemon Dechibified Platinum](https://www.nexusmods.com/pokemonbdsp/mods/38)                     | Adomin8er                | 2.2F                      | 	Has versions for vanilla, Lumi, and Coronet.|
 | [Shinyn't Eggs](https://www.nexusmods.com/pokemonbdsp/mods/24)                      | DJ                      | 2.2F                      |                           |
 | [Xbox and Steam Deck Button Swap](https://www.nexusmods.com/pokemonbdsp/mods/4)     | Leoparodo               | 2.1F                      |                           |
 | [Xbox UI Overhaul](https://www.nexusmods.com/pokemonbdsp/mods/11)                   | Pixelguin               | 2.1F                      |                           |
+| [Restore PokeCenter Animation](https://www.nexusmods.com/pokemonbdsp/mods/51)                   | Blup               | 2.2F                      | Restores the healing animation.                          |
+| [Pocket PokeCenter](https://www.nexusmods.com/pokemonbdsp/mods/56)                   | Blup               | 2.2F                      | Adds an item to trigger a full heal anywhere.       |
+| [Lumi Easy-Mode](https://www.nexusmods.com/pokemonbdsp/mods/53)                   | Blup               | 2.2F                      | Replaces teams with vanilla BDSP ones.       |
+| [Shiny Icons](https://www.nexusmods.com/pokemonbdsp/mods/62)                   | Blup               | 2.2F                      |        |
+| [Exp Multiplier](https://www.nexusmods.com/pokemonbdsp/mods/75)                   | Blup               | 2.2F                      |      |
+| [Chibi Head Size Adjusted](https://www.nexusmods.com/pokemonbdsp/mods/82)                   | Blup               | 2.2F                      | Reduces the size of chibi heads.       |
+| [Double Battles Everywhere](https://www.nexusmods.com/pokemonbdsp/mods/76)                   | Blup               | 2.2F                      | Makes every battle a double battle       |
+| [Remove Random Trainer Teams](https://www.nexusmods.com/pokemonbdsp/mods/87)                   | Blup               | 2.2F                      |       |
 
 # Overhaul Mods
 
@@ -48,7 +58,8 @@ These Overhaul mods aim to change large aspects of the game. Some of these may h
 
 | Overhaul Mods                                                                       | Author                  | Notes                     |
 | ----------------------------------------------------------------------------------- | ----------------------- | ------------------------- |
-| [Coronet Forms](https://www.nexusmods.com/pokemonbdsp/mods/20)                      | Team Coronet            |                           |
+| [Coronet Forms](https://www.nexusmods.com/pokemonbdsp/mods/20)                      | Team Coronet            | 2.2F                          |
+| [Reformed Platinum](https://www.nexusmods.com/pokemonbdsp/mods/32)                      | Adomin8er            | 2.1F                          |
 
 # Translations
 
@@ -56,8 +67,8 @@ These mods are translation patches for Luminescent Platinum into other languages
 
 | Translation Mods                                                                    | Author                  | Notes                     |
 | ----------------------------------------------------------------------------------- | ----------------------- | ------------------------- |
-| [Luminescent Platinum GERMAN Translation Patch - Luminoeses Platin](https://www.nexusmods.com/pokemonbdsp/mods/23)                     | Team Deudle             | 2.1F                      | German Translation np|
-| [Luminescent Platinum Korean Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/31)                     | Yurical              | 2.1F                      | Korean Translation np|
-| [Luminescent Platinum Spanish (Spain) Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/49)                     | Chaotic Spaniards               | 2.1F                      | Spanish Translation np|
-| [Luminescent Platinum Traditional Chinese Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/37)                     | FrozenZero              | 2.1F                      | Traditional Chinese Translation np|
-| [Luminescent Platinum French Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/44)                     | Team French              | 2.1F                      | French Translation np|
+| [Luminescent Platinum GERMAN Translation Patch - Luminoeses Platin](https://www.nexusmods.com/pokemonbdsp/mods/23)                     | Team Deudle             | 2.1F (compatible with 2.2F)                     | German Translation np|
+| [Luminescent Platinum Korean Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/31)                     | Yurical              | 2.2F                      | Korean Translation np|
+| [Luminescent Platinum Spanish (Spain) Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/49)                     | Chaotic Spaniards               | 2.2F                      | Spanish Translation np|
+| [Luminescent Platinum Traditional Chinese Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/37)                     | FrozenZero              | 2.1F (compatible with 2.2F)                     | Traditional Chinese Translation np|
+| [Luminescent Platinum French Translation Patch](https://www.nexusmods.com/pokemonbdsp/mods/44)                     | Team French              | 2.1F (compatible with 2.2F)                     | French Translation np|

--- a/docs/mods.mdx
+++ b/docs/mods.mdx
@@ -38,7 +38,7 @@ New mods release often, if you want to make sure you are not missing anything, y
 | [Hisui Pokeballs](https://www.nexusmods.com/pokemonbdsp/mods/14)                    | ProfBlack               | 2.2F                      |                           |
 | [Luminescent Platinum name and icon](https://www.nexusmods.com/pokemonbdsp/mods/5)  | FlavvArouf              | 2.2F                      | Only works on hardware.   |
 | [No Bike Outfit](https://www.nexusmods.com/pokemonbdsp/mods/25)                     | DJ                      | 2.2F                      |                           |
-| [Original Base Stats for Luminescent Platinum](https://www.nexusmods.com/pokemonbdsp/mods/48/) | ClemiNeko  | 2.2F                      | Option for base stats, typings and learnsets.|
+| [Revert Balance Changes](https://www.nexusmods.com/pokemonbdsp/mods/48/) | ClemiNeko  | 2.2F                      | Option for base stats, typings and learnsets.|
 | [Playstation Button Swap](https://www.nexusmods.com/pokemonbdsp/mods/8)             | Leoparodo               | 2.1F                      |                           |
 | [Shinyn't Eggs](https://www.nexusmods.com/pokemonbdsp/mods/24)                      | DJ                      | 2.2F                      |                           |
 | [Xbox and Steam Deck Button Swap](https://www.nexusmods.com/pokemonbdsp/mods/4)     | Leoparodo               | 2.1F                      |                           |


### PR DESCRIPTION
(The diff seems to be broken because of updated line endings, but you can enable "hide whitespace changes" in the settings menu of the files changed tab)

- Updated the caution message in the Atmosphere and Ryujinx installation pages to link to the compatible mods list instead of saying users should not install any other mods
- Added `(compatible with 2.2F)`  to language patches that have not been updated, to avoid confusing users.
- Moved Dechibified from the bottom of the list to the top since it's the most popular patch for Lumi
- Added entries for Lumi Resaturated, Increased Shiny Odds, and other newly added patches
- Added Reformed Platinum to the list of Overhaul mods
- Removed "Original Typings for Luminescent Platinum" since it's outdated and already covered by the "No Balance Changes" mod
