### PR TITLE
Command documentation

### DIFF
--- a/rom-hacking/scripting/commands/battle/401-wild-btl-set.md
+++ b/rom-hacking/scripting/commands/battle/401-wild-btl-set.md
@@ -1,0 +1,25 @@
+# (401) _WILD_BTL_SET
+
+## Effect
+
+Initiates a wild battle.
+
+## Syntax
+
+```c
+_WILD_BTL_SET(monsno, level)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **monsno** | The NatDex ID of the Pokémon to battle | Work, Number | Required |
+| **level** | The level of the Pokémon | Work, Number | Required |
+
+## Example
+
+```c
+_WILD_BTL_SET(133, 34)
+```
+
+The above script will start a wild battle with an Eevee at level 34.
+

--- a/rom-hacking/scripting/commands/battle/402-sp-wild-btl-set.md
+++ b/rom-hacking/scripting/commands/battle/402-sp-wild-btl-set.md
@@ -1,0 +1,31 @@
+# (402) _SP_WILD_BTL_SET
+
+## Effect
+
+Initiates a wild battle with more arguments than [_WILD_BTL_SET](401-wild-btl-set.md).
+
+## Syntax
+
+```c
+_SP_WILD_BTL_SET(monsno, level, isCantUseBall, formno, hiddenAbility)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **monsno** | The NatDex ID of the Pokémon to battle | Work, Number | Required |
+| **level** | The level of the Pokémon | Work, Number | Required |
+| **isCantUseBall** | If set to 1, you will be unable to throw a Poké Ball in this battle | Work, Number | Optional |
+| **formno** | The form of the Pokémon | Work, Number | Optional |
+| **hiddenAbility** | If set to 1, the Pokémon will have its Hidden Ability | Work, Number | Optional |
+
+:::info
+The combination of Giratina with Form 1 and isCantUseBall will force Giratina to appear in its Shadow Origin Forme.
+:::
+
+## Example
+
+```c
+_SP_WILD_BTL_SET(422, 20, 0, 1, 1)
+```
+
+The above script will start a wild battle with a catchable East Sea Shellos at level 20 with its Hidden Ability.

--- a/rom-hacking/scripting/commands/gamedata/1209-add-pokemon-ui.md
+++ b/rom-hacking/scripting/commands/gamedata/1209-add-pokemon-ui.md
@@ -1,0 +1,27 @@
+# (1209) _ADD_POKEMON_UI
+
+## Effect
+
+Add a Pokémon to the party with the UI that gives the player options for various things to do with it.
+
+## Syntax
+
+```c
+_ADD_POKEMON_UI(monsno, level, item, result, maxIVs)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **monsno** | The NatDex ID of the Pokémon | Work, Number | Required |
+| **level** | The level of the Pokémon | Work, Number | Required |
+| **item** | The item ID that the Pokémon will hold (0 = no item) | Work, Number | Required |
+| **result** | The result is always set to 0 | Work | Required |
+| **maxIVs** |The number of max IVs the Pokémon will be forced to have | Work, Number | Optional |
+
+## Example
+
+```c
+_ADD_POKEMON_UI(328, 27, 92, @SCWK_ANSWER, 3)
+```
+
+The above script will give the player an Trapinch at level 27 holding a nugget and with at least three maxed IVs. It will pop up a UI with options to rename, look at the summary and choose where to send it.

--- a/rom-hacking/scripting/commands/gamedata/218-add-pokemon.md
+++ b/rom-hacking/scripting/commands/gamedata/218-add-pokemon.md
@@ -1,0 +1,31 @@
+# (218) _ADD_POKEMON
+
+## Effect
+
+Add a Pokémon to the party silently.
+
+## Syntax
+
+```c
+_ADD_POKEMON(monsno, level, item, result, maxIVs)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **monsno** | The NatDex ID of the Pokémon | Work, Number | Required |
+| **level** | The level of the Pokémon | Work, Number | Required |
+| **item** | The item ID that the Pokémon will hold (0 = no item) | Work, Number | Required |
+| **result** | The result of if there was room in the party | Work | Required |
+| **maxIVs** |The number of max IVs the Pokémon will be forced to have | Work, Number | Optional |
+
+:::info
+The Pokémon will be registered in the Pokédex regardless of the `result`.
+:::
+
+## Example
+
+```c
+_ADD_POKEMON(133, 34, 0, @SCWK_ANSWER, 5)
+```
+
+The above script will give the player an Eevee at level 34 holding no item and with at least five maxed IVs, if there is room in the party.

--- a/rom-hacking/scripting/commands/interface/1036-load-camera-controller.md
+++ b/rom-hacking/scripting/commands/interface/1036-load-camera-controller.md
@@ -1,0 +1,29 @@
+# (1036) _LOAD_CAMERA_CONTROLLER
+
+## Effect
+
+Loads an assetbundle with an Animator Controller in the `field/camera` directory. Only one of these can be loaded at one time.
+
+These assetbundles contain Animation Clips that can be called with [_CAMERA_CONTROLLER_PLAY](1038-camera-controller-play.md) to serve as a track for the Field Camera to be attached to.
+
+## Syntax
+
+```c
+_LOAD_CAMERA_CONTROLLER(assetbundlePath)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **assetbundlePath** | The path to the assetbundle | String | Required |
+
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes.

--- a/rom-hacking/scripting/commands/interface/1037-load-wait-camera-controller.md
+++ b/rom-hacking/scripting/commands/interface/1037-load-wait-camera-controller.md
@@ -1,0 +1,22 @@
+# (1037) _LOAD_WAIT_CAMERA_CONTROLLER
+
+## Effect
+
+Waits for a camera controller to be loaded with [_LOAD_CAMERA_CONTROLLER](1036-load-camera-controller.md). Script execution is paused until then.
+
+## Syntax
+
+```c
+_LOAD_WAIT_CAMERA_CONTROLLER()
+```
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes.

--- a/rom-hacking/scripting/commands/interface/1038-camera-controller-play.md
+++ b/rom-hacking/scripting/commands/interface/1038-camera-controller-play.md
@@ -1,0 +1,26 @@
+# (1038) _CAMERA_CONTROLLER_PLAY
+
+## Effect
+
+Attaches the Field Camera to the root object of a given Animation Clip and plays it.
+
+## Syntax
+
+```c
+_CAMERA_CONTROLLER_PLAY(animationClip)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **animationClip** | The name of the Animation Clip | String | Required |
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes.

--- a/rom-hacking/scripting/commands/interface/1039-camera-controller-end.md
+++ b/rom-hacking/scripting/commands/interface/1039-camera-controller-end.md
@@ -1,0 +1,23 @@
+# (1039) _CAMERA_CONTROLLER_END
+
+## Effect
+
+Reattaches the Field Camera to the player after a Camera Controller animation.
+
+## Syntax
+
+```c
+_CAMERA_CONTROLLER_END()
+```
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+_CAMERA_CONTROLLER_END()
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes. The camera is then reattached to the player.

--- a/rom-hacking/scripting/commands/interface/1049-release-camera-controller.md
+++ b/rom-hacking/scripting/commands/interface/1049-release-camera-controller.md
@@ -1,0 +1,24 @@
+# (1049) _RELEASE_CAMERA_CONTROLLER
+
+## Effect
+
+Unloads a Camera Controller assetbundle that had been loaded with [_LOAD_CAMERA_CONTROLLER](1036-load-camera-controller.md).
+
+## Syntax
+
+```c
+_RELEASE_CAMERA_CONTROLLER()
+```
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+_CAMERA_CONTROLLER_END()
+_RELEASE_CAMERA_CONTROLLER()
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes. The camera is then reattached to the player and the assetbundle is unloaded.

--- a/rom-hacking/scripting/commands/interface/1069-camera-controller-wait.md
+++ b/rom-hacking/scripting/commands/interface/1069-camera-controller-wait.md
@@ -1,0 +1,26 @@
+# (1069) _CAMERA_CONTROLLER_WAIT
+
+## Effect
+
+Waits for a camera controller animation called by [_CAMERA_CONTROLLER_PLAY](1038-camera-controller-play.md) to finish. Script execution is paused until then.
+
+## Syntax
+
+```c
+_CAMERA_CONTROLLER_WAIT(animationClip)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **animationClip** | The name of the Animation Clip | String | Required |
+
+## Example
+
+```c
+_LOAD_CAMERA_CONTROLLER('field/camera/chapter110')
+_LOAD_WAIT_CAMERA_CONTROLLER()
+_CAMERA_CONTROLLER_PLAY('chapter110-001_cut01')
+_CAMERA_CONTROLLER_WAIT('chapter110-001_cut01')
+```
+
+The above script loads the `field/camera/chapter110` assetbundle and will wait for it to be loaded. Then it will attach the Field Camera to the root object of the Animation Clip called `chapter110-001_cut01` and will play it until it finishes.

--- a/rom-hacking/scripting/commands/interface/1096-load-uma-anime.md
+++ b/rom-hacking/scripting/commands/interface/1096-load-uma-anime.md
@@ -1,0 +1,31 @@
+# (1096) _LOAD_UMA_ANIME
+
+## Effect
+
+Loads the assetbundle with an Animator Controller `field/animeobj/chapter111`.
+
+This assetbundle contains Animation Clips that can be called with [_UMA_ANIME_PLAY](1099-uma-anime-play.md) to serve as a track for PlaceData to be attached to.
+
+## Syntax
+
+```c
+_LOAD_UMA_ANIME()
+```
+
+## Example
+
+```c
+_LOAD_UMA_ANIME()
+_LOAD_UMA_ANIME_WAIT()
+_UMA_ANIME_ATTACH(0, 'DUMMY_UXIE')
+_UMA_ANIME_ATTACH(1, 'DUMMY_MESPIRIT')
+_UMA_ANIME_ATTACH(2, 'DUMMY_AZELF')
+_UMA_ANIME_PLAY(0, 'chapter111-01_cut06a_pm0480_00_00_yuxie')
+_UMA_ANIME_PLAY(1, 'chapter111-01_cut06a_pm0481_00_00_emrit')
+_UMA_ANIME_PLAY(2, 'chapter111-01_cut06a_pm0482_00_00_agnome')
+_UMA_PLAY_WAIT(0, 'DUMMY_UXIE')
+_UMA_PLAY_WAIT(1, 'DUMMY_MESPIRIT')
+_UMA_PLAY_WAIT(2, 'DUMMY_AZELF')
+```
+
+The above script loads the `field/animeobj/chapter111` assetbundle and will wait for it to be loaded. Then it will attach the three **U**xie, **M**espirit and **A**zelf PlaceData to UMA index 0, 1 and 2 respectively. It then calls Animation Clips from the assetbundle for each of them and will play it until they finish.

--- a/rom-hacking/scripting/commands/interface/1097-release-uma-anime.md
+++ b/rom-hacking/scripting/commands/interface/1097-release-uma-anime.md
@@ -1,4 +1,4 @@
-# (1087) _RELEASE_UMA_ANIME
+# (1097) _RELEASE_UMA_ANIME
 
 ## Effect
 

--- a/rom-hacking/scripting/commands/interface/1097-release-uma-anime.md
+++ b/rom-hacking/scripting/commands/interface/1097-release-uma-anime.md
@@ -1,0 +1,34 @@
+# (1087) _RELEASE_UMA_ANIME
+
+## Effect
+
+Unloads the `field/camera/chapter110` assetbundle loaded by [_LOAD_UMA_ANIME](1096-load-uma-anime.md).
+
+:::caution
+_RELEASE_UMA_ANIME will crash if fewer than three UMA entities are attached.
+:::
+
+## Syntax
+
+```c
+_RELEASE_UMA_ANIME()
+```
+
+## Example
+
+```c
+_LOAD_UMA_ANIME()
+_LOAD_UMA_ANIME_WAIT()
+_UMA_ANIME_ATTACH(0, 'DUMMY_UXIE')
+_UMA_ANIME_ATTACH(1, 'DUMMY_MESPIRIT')
+_UMA_ANIME_ATTACH(2, 'DUMMY_AZELF')
+_UMA_ANIME_PLAY(0, 'chapter111-01_cut06a_pm0480_00_00_yuxie')
+_UMA_ANIME_PLAY(1, 'chapter111-01_cut06a_pm0481_00_00_emrit')
+_UMA_ANIME_PLAY(2, 'chapter111-01_cut06a_pm0482_00_00_agnome')
+_UMA_PLAY_WAIT(0, 'DUMMY_UXIE')
+_UMA_PLAY_WAIT(1, 'DUMMY_MESPIRIT')
+_UMA_PLAY_WAIT(2, 'DUMMY_AZELF')
+_RELEASE_UMA_ANIME()
+```
+
+The above script loads the `field/animeobj/chapter111` assetbundle and will wait for it to be loaded. Then it will attach the three **U**xie, **M**espirit and **A**zelf PlaceData to UMA index 0, 1 and 2 respectively. It then calls Animation Clips from the assetbundle for each of them and will play it until they finish. The attached entities remain where they are as the `field/animeobj/chapter111` assetbundle is unloaded.

--- a/rom-hacking/scripting/commands/interface/1098-load-uma-anime-wait.md
+++ b/rom-hacking/scripting/commands/interface/1098-load-uma-anime-wait.md
@@ -1,0 +1,29 @@
+# (1098) _LOAD_UMA_ANIME_WAIT
+
+## Effect
+
+Waits for the `field/animeobj/chapter111` assetbundle to be loaded with [_LOAD_UMA_ANIME](1096-load-uma-anime.md). Script execution is paused until then.
+
+## Syntax
+
+```c
+_LOAD_UMA_ANIME_WAIT()
+```
+
+## Example
+
+```c
+_LOAD_UMA_ANIME()
+_LOAD_UMA_ANIME_WAIT()
+_UMA_ANIME_ATTACH(0, 'DUMMY_UXIE')
+_UMA_ANIME_ATTACH(1, 'DUMMY_MESPIRIT')
+_UMA_ANIME_ATTACH(2, 'DUMMY_AZELF')
+_UMA_ANIME_PLAY(0, 'chapter111-01_cut06a_pm0480_00_00_yuxie')
+_UMA_ANIME_PLAY(1, 'chapter111-01_cut06a_pm0481_00_00_emrit')
+_UMA_ANIME_PLAY(2, 'chapter111-01_cut06a_pm0482_00_00_agnome')
+_UMA_PLAY_WAIT(0, 'DUMMY_UXIE')
+_UMA_PLAY_WAIT(1, 'DUMMY_MESPIRIT')
+_UMA_PLAY_WAIT(2, 'DUMMY_AZELF')
+```
+
+The above script loads the `field/animeobj/chapter111` assetbundle and will wait for it to be loaded. Then it will attach the three **U**xie, **M**espirit and **A**zelf PlaceData to UMA index 0, 1 and 2 respectively. It then calls Animation Clips from the assetbundle for each of them and will play it until they finish.

--- a/rom-hacking/scripting/commands/interface/1099-uma-anime-play.md
+++ b/rom-hacking/scripting/commands/interface/1099-uma-anime-play.md
@@ -1,0 +1,34 @@
+# (1099) _UMA_ANIME_PLAY
+
+## Effect
+
+Attaches the PlaceData that was attached to the given index with [_UMA_ANIME_ATTACH](1100-uma-anime-attach.md) to the root object of a given Animation Clip and plays it.
+
+## Syntax
+
+```c
+_UMA_ANIME_PLAY(index, animationClip)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **index** | The assigned index of the PlaceData | Number, Work | Required |
+| **animationClip** | The name of the Animation Clip | String | Required |
+
+## Example
+
+```c
+_LOAD_UMA_ANIME()
+_LOAD_UMA_ANIME_WAIT()
+_UMA_ANIME_ATTACH(0, 'DUMMY_UXIE')
+_UMA_ANIME_ATTACH(1, 'DUMMY_MESPIRIT')
+_UMA_ANIME_ATTACH(2, 'DUMMY_AZELF')
+_UMA_ANIME_PLAY(0, 'chapter111-01_cut06a_pm0480_00_00_yuxie')
+_UMA_ANIME_PLAY(1, 'chapter111-01_cut06a_pm0481_00_00_emrit')
+_UMA_ANIME_PLAY(2, 'chapter111-01_cut06a_pm0482_00_00_agnome')
+_UMA_PLAY_WAIT(0, 'DUMMY_UXIE')
+_UMA_PLAY_WAIT(1, 'DUMMY_MESPIRIT')
+_UMA_PLAY_WAIT(2, 'DUMMY_AZELF')
+```
+
+The above script loads the `field/animeobj/chapter111` assetbundle and will wait for it to be loaded. Then it will attach the three **U**xie, **M**espirit and **A**zelf PlaceData to UMA index 0, 1 and 2 respectively. It then calls Animation Clips from the assetbundle for each of them and will play it until they finish.

--- a/rom-hacking/scripting/commands/interface/1100-uma-anime-attach.md
+++ b/rom-hacking/scripting/commands/interface/1100-uma-anime-attach.md
@@ -1,0 +1,40 @@
+# (1100) _UMA_ANIME_ATTACH
+
+## Effect
+
+Attaches a given entity to index 0, 1 or 2, for use with [_UMA_ANIME_PLAY](1099-uma-anime-play.md).
+
+:::caution
+You must always attach entities to all three indices, whether you plan to play animations on three entities or not.
+
+_RELEASE_UMA_ANIME will crash if fewer than three UMA entities are attached.
+:::
+
+## Syntax
+
+```c
+_UMA_ANIME_ATTACH(index, entity)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **index** | The UMA index that you assigning an entity to | Number, Work | Required |
+| **entity** | The entity id | String, Number, Work | Required |
+
+## Example
+
+```c
+_LOAD_UMA_ANIME()
+_LOAD_UMA_ANIME_WAIT()
+_UMA_ANIME_ATTACH(0, 'DUMMY_UXIE')
+_UMA_ANIME_ATTACH(1, 'DUMMY_MESPIRIT')
+_UMA_ANIME_ATTACH(2, 'DUMMY_AZELF')
+_UMA_ANIME_PLAY(0, 'chapter111-01_cut06a_pm0480_00_00_yuxie')
+_UMA_ANIME_PLAY(1, 'chapter111-01_cut06a_pm0481_00_00_emrit')
+_UMA_ANIME_PLAY(2, 'chapter111-01_cut06a_pm0482_00_00_agnome')
+_UMA_PLAY_WAIT(0, 'DUMMY_UXIE')
+_UMA_PLAY_WAIT(1, 'DUMMY_MESPIRIT')
+_UMA_PLAY_WAIT(2, 'DUMMY_AZELF')
+```
+
+The above script loads the `field/animeobj/chapter111` assetbundle and will wait for it to be loaded. Then it will attach the three **U**xie, **M**espirit and **A**zelf PlaceData to UMA index 0, 1 and 2 respectively. It then calls Animation Clips from the assetbundle for each of them and will play it until they finish.

--- a/rom-hacking/scripting/commands/interface/1136-camera-controller-is-null.md
+++ b/rom-hacking/scripting/commands/interface/1136-camera-controller-is-null.md
@@ -1,0 +1,31 @@
+# (1136) _CAMERA_CONTROLLER_IS_NULL
+
+## Effect
+
+Checks if a Camera Controller is currently loaded and stores the result in a work variable.
+
+The result will be 0 if a Camera Controller is loaded and 1 if it is not.
+
+## Syntax
+
+```c
+_CAMERA_CONTROLLER_IS_NULL(result)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **result** | Result of if a Camera Controller is loaded | Work | Required |
+
+
+## Example
+
+```c
+ev_dummy:
+_CAMERA_CONTROLLER_IS_NULL(@LOCALWORK1)
+_IFVAL_CALL(@LOCALWORK1, 'EQ', 0, 'ev_dummy_release')
+ev_dummy_release:
+_RELEASE_CAMERA_CONTROLLER()
+_RET()
+```
+
+The above script checks if a Camera Controller is loaded and calls a script to unload it if one is.

--- a/rom-hacking/scripting/commands/interface/1137-uma-is-null.md
+++ b/rom-hacking/scripting/commands/interface/1137-uma-is-null.md
@@ -1,0 +1,31 @@
+# (1137) _UMA_IS_NULL
+
+## Effect
+
+Checks if an UMA Anime Controller is currently loaded and stores the result in a work variable.
+
+The result will be 0 if an UMA Anime Controller is loaded and 1 if it is not.
+
+## Syntax
+
+```c
+_UMA_IS_NULL(result)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **result** | Result of if an UMA Anime Controller is loaded | Work | Required |
+
+
+## Example
+
+```c
+ev_dummy:
+_UMA_IS_NULL(@LOCALWORK1)
+_IFVAL_CALL(@LOCALWORK1, 'EQ', 0, 'ev_dummy_release')
+ev_dummy_release:
+_RELEASE_UMA_ANIME()
+_RET()
+```
+
+The above script checks if an UMA Anime Controller is loaded and calls a script to unload it if one is.

--- a/rom-hacking/scripting/commands/interface/814-camera-target-hero.md
+++ b/rom-hacking/scripting/commands/interface/814-camera-target-hero.md
@@ -1,0 +1,32 @@
+# (814) _CAMERA_TARGET_HERO
+
+## Effect
+
+Attaches the Field Camera to the player.
+
+## Syntax
+
+```c
+_CAMERA_TARGET_HERO()
+```
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_SET_POS_HERO()
+_CAMERA_TARGET_DUMMY()
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+_BLACK_OUT()
+_FADE_WAIT()
+_DUMMY_SET_POS_HERO()
+_CAMERA_TARGET_HERO()
+_BLACK_IN()
+_FADE_WAIT()
+anm_dummy:
+_AC_UP(5, 8)
+_ACMD_END()
+```
+
+The above script will move the Dummy Field Object to the position of the player. It will then attach the Field Camera to it and move forward by 5 tiles. It then blacks out the screen, moves the Dummy Field Object back to the player and re-attaches the Field Camera to the player before fading the screen back in.

--- a/rom-hacking/scripting/commands/interface/815-camera-target-dummy.md
+++ b/rom-hacking/scripting/commands/interface/815-camera-target-dummy.md
@@ -1,0 +1,32 @@
+# (815) _CAMERA_TARGET_DUMMY
+
+## Effect
+
+Attaches the Field Camera to the invisible Dummy Field Object.
+
+## Syntax
+
+```c
+_CAMERA_TARGET_DUMMY()
+```
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_SET_POS_HERO()
+_CAMERA_TARGET_DUMMY()
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+_BLACK_OUT()
+_FADE_WAIT()
+_DUMMY_SET_POS_HERO()
+_CAMERA_TARGET_HERO()
+_BLACK_IN()
+_FADE_WAIT()
+anm_dummy:
+_AC_UP(5, 8)
+_ACMD_END()
+```
+
+The above script will move the Dummy Field Object to the position of the player. It will then attach the Field Camera to it and move forward by 5 tiles. It then blacks out the screen, moves the Dummy Field Object back to the player and re-attaches the Field Camera to the player before fading the screen back in.

--- a/rom-hacking/scripting/commands/interface/816-dummy-anime.md
+++ b/rom-hacking/scripting/commands/interface/816-dummy-anime.md
@@ -1,0 +1,31 @@
+# (816) _DUMMY_ANIME
+
+## Effect
+
+Calls an animation label for the invisible Dummy Field Object.
+
+## Syntax
+
+```c
+_DUMMY_ANIME(label)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **label** | The animation label | String | Required |
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_SET_POS(67, 69)
+_CAMERA_TARGET_DUMMY()
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+anm_dummy:
+_AC_UP(2, 8)
+_AC_RIGHT(2, 8)
+_ACMD_END()
+```
+
+The above script will move the Dummy Field Object to 67 X, 69 Z. It will then attach the Field Camera to it and move to 69 X, 67 Z. Script execu

--- a/rom-hacking/scripting/commands/interface/817-dummy-anime-wait.md
+++ b/rom-hacking/scripting/commands/interface/817-dummy-anime-wait.md
@@ -1,0 +1,25 @@
+# (817) _DUMMY_ANIME_WAIT
+
+## Effect
+
+Waits for an animation called by [_DUMMY_ANIME](816-dummy-anime.md) to finish. Script execution is paused until then.
+
+If this command is not used, the script will continue to run while the animation is ongoing.
+
+## Syntax
+
+```c
+_DUMMY_ANIME_WAIT()
+```
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+anm_dummy:
+_ACMD_END()
+```
+
+The above script will call an animation function and wait for the animation function to finish before executing the rest of the script.

--- a/rom-hacking/scripting/commands/interface/818-dummy-set-pos.md
+++ b/rom-hacking/scripting/commands/interface/818-dummy-set-pos.md
@@ -1,0 +1,35 @@
+# (818) _DUMMY_SET_POS
+
+## Effect
+
+Moves the invisible Dummy Field Object to the specified X and Z coordinates.
+
+The Field Camera can be attached to this Dummy object for simple camera moves.
+
+## Syntax
+
+```c
+_DUMMY_SET_POS(X, Z)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **X** | The X coordinate | Number, Work | Required |
+| **Z** | The Z coordinate | Number, Work | Required |
+
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_SET_POS(67, 69)
+_CAMERA_TARGET_DUMMY()
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+anm_dummy:
+_AC_UP(2, 8)
+_AC_RIGHT(2, 8)
+_ACMD_END()
+```
+
+The above script will move the Dummy Field Object to 67 X, 69 Z. It will then attach the Field Camera to it and move to 69 X, 67 Z.

--- a/rom-hacking/scripting/commands/interface/819-dummy-set-pos-hero.md
+++ b/rom-hacking/scripting/commands/interface/819-dummy-set-pos-hero.md
@@ -1,0 +1,28 @@
+# (819) _DUMMY_SET_POS_HERO
+
+## Effect
+
+Moves the invisible Dummy Field Object to the position of the player.
+
+The Field Camera can be attached to this Dummy object for simple camera moves.
+
+## Syntax
+
+```c
+_DUMMY_SET_POS_HERO()
+```
+
+## Example
+
+```c
+ev_dummy:
+_DUMMY_SET_POS_HERO()
+_CAMERA_TARGET_DUMMY()
+_DUMMY_ANIME('anm_dummy')
+_DUMMY_ANIME_WAIT()
+anm_dummy:
+_AC_UP(5, 8)
+_ACMD_END()
+```
+
+The above script will move the Dummy Field Object to the position of the player. It will then attach the Field Camera to it and move forward by 5 tiles.

--- a/rom-hacking/scripting/commands/interface/880-ac_anim_lock.md
+++ b/rom-hacking/scripting/commands/interface/880-ac_anim_lock.md
@@ -1,0 +1,34 @@
+# (880) _AC_ANIM_LOCK
+
+## Effect
+
+Locks the designated entity to loop the currently playing animation after it has finished playing, rather than going back to its wait animation.
+
+The entity will return to its wait animation when the script ends or when [_AC_ANIM_RELEASE](881-ac_anim_release.md) is called on them.
+
+## Syntax
+
+```c
+_AC_ANIM_LOCK(id)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **id** | The ID of the PlaceData | String, Number, Work | Required |
+
+
+## Example
+
+```c
+ev_dummy:
+_AC_ANIM_LOCK('HERO')
+_OBJ_ANIME('HERO', 'anm_dummy')
+anm_dummy:
+_AC_INDEX_ANIME(26)
+_AC_INDEX_ANIME_WAIT()
+_AC_INDEX_ANIME(27)
+_AC_INDEX_ANIME_WAIT()
+_ACMD_END()
+```
+
+The above script will lock the animation state of the player, call an animation function and change them to use animation 26 (surprise start), then followed by animation 27 (surprise loop), locking them to loop animation 27, as it was the last one called.

--- a/rom-hacking/scripting/commands/interface/881-ac_anim_release.md
+++ b/rom-hacking/scripting/commands/interface/881-ac_anim_release.md
@@ -1,0 +1,38 @@
+# (881) _AC_ANIM_RELEASE
+
+## Effect
+
+Unlocks the designated entity's animation state if it was locked previously with [_AC_ANIM_LOCK](880-ac_anim_lock.md).
+
+The entity will return to its wait animation.
+
+## Syntax
+
+```c
+_AC_ANIM_RELEASE(id)
+```
+
+| Argument | Description | Types | Required |
+| - | - | - | - |
+| **id** | The ID of the PlaceData | String, Number, Work | Required |
+
+
+## Example
+
+```c
+ev_dummy:
+_AC_ANIM_LOCK('HERO')
+_OBJ_ANIME('HERO', 'anm_dummy')
+_TIME_WAIT(200, @SCWK_ANSWER)
+_AC_ANIM_RELEASE('HERO')
+anm_dummy:
+_AC_INDEX_ANIME(26)
+_AC_INDEX_ANIME_WAIT()
+_AC_INDEX_ANIME(27)
+_AC_INDEX_ANIME_WAIT()
+_ACMD_END()
+```
+
+The above script will lock the animation state of the player, call an animation function and change them to use animation 26 (surprise start), then followed by animation 27 (surprise loop), locking them to loop animation 27, as it was the last one called.
+
+Then it waits 200 frames and unlocks them, letting them go back to their normal wait animation.

--- a/rom-hacking/scripting/commands/logic/151-talk-obj-start.md
+++ b/rom-hacking/scripting/commands/logic/151-talk-obj-start.md
@@ -1,0 +1,22 @@
+# (151) _TALK_OBJ_START
+
+## Effect
+
+Starts a talk object script event with the placedata that called the script containing this command and makes an interaction noise. Locking player input until [_TALK_OBJ_END](153-talk-obj-end.md) is called.
+
+Field Entities (NPCs, Pokémon, Gimmick objects) will turn to face the player and the player will turn to face them.
+
+## Syntax
+
+```c
+_TALK_OBJ_START()
+```
+
+## Example
+
+```c
+ev_dummy:
+_TALK_OBJ_START()
+```
+
+The above script will make an interaction noise, lock player input and force them to face the placedata that called the script. If the placedata is an entity, they will turn to face the player too.

--- a/rom-hacking/scripting/commands/logic/152-talk-obj-start-turn-not.md
+++ b/rom-hacking/scripting/commands/logic/152-talk-obj-start-turn-not.md
@@ -1,0 +1,22 @@
+# (152) _TALK_OBJ_START_TURN_NOT
+
+## Effect
+
+Starts a talk object script event with the placedata that called the script containing this command and makes an interaction noise. Locking player input until [_TALK_OBJ_END](153-talk-obj-end.md) is called.
+
+Field Character Entities (NPCs) will turn their neck in the direction of the player but not their body. The player will turn their whole body to face them.
+
+## Syntax
+
+```c
+_TALK_OBJ_START_TURN_NOT()
+```
+
+## Example
+
+```c
+ev_dummy:
+_TALK_OBJ_START_TURN_NOT()
+```
+
+The above script will make an interaction noise, lock player input and force them to face the placedata that called the script. If the placedata is an Field Character Entity, they will turn their neck in the direction of the player.

--- a/rom-hacking/scripting/commands/logic/153-talk-obj-end.md
+++ b/rom-hacking/scripting/commands/logic/153-talk-obj-end.md
@@ -1,0 +1,23 @@
+# (153) _TALK_OBJ_END
+
+## Effect
+
+Unlocks player input in the current script event.
+
+The player and the placedata that called the script (if one is present) will stop being forced to face each other.
+
+## Syntax
+
+```c
+_TALK_OBJ_END()
+```
+
+## Example
+
+```c
+_TALK_OBJ_END()
+_SE_PLAY('S_PINPON')
+_END()
+```
+
+The above script will unlock the player and placedata and will then play the 'S_PINPON' sound effect. The player will be able to move while the sound effect is playing.

--- a/rom-hacking/scripting/commands/logic/154-talk-start.md
+++ b/rom-hacking/scripting/commands/logic/154-talk-start.md
@@ -1,0 +1,24 @@
+# (154) _TALK_START
+
+## Synonyms
+
+- _TALK_OBJ_START_LOOK_NONE
+
+## Effect
+
+Starts a talk script event with an interaction noise. Locking player input until [_TALK_END](156-talk-end.md) is called.
+
+## Syntax
+
+```c
+_TALK_START()
+```
+
+## Example
+
+```c
+ev_dummy:
+_TALK_START()
+```
+
+The above script will make an interaction noise and lock player input.

--- a/rom-hacking/scripting/commands/logic/155-event-start.md
+++ b/rom-hacking/scripting/commands/logic/155-event-start.md
@@ -1,0 +1,20 @@
+# (155) _EVENT_START
+
+## Effect
+
+Starts a script event. Locking player input until [_EVENT_END](157-event-end.md) is called.
+
+## Syntax
+
+```c
+_EVENT_START()
+```
+
+## Example
+
+```c
+ev_dummy:
+_EVENT_START()
+```
+
+The above script will lock player input.

--- a/rom-hacking/scripting/commands/logic/156-talk-end.md
+++ b/rom-hacking/scripting/commands/logic/156-talk-end.md
@@ -1,0 +1,25 @@
+# (156) _TALK_END
+
+## Synonyms
+
+- [_EVENT_END](157-event-end.md)
+
+## Effect
+
+Unlocks player input in the current script event.
+
+## Syntax
+
+```c
+_TALK_END()
+```
+
+## Example
+
+```c
+_TALK_END()
+_SE_PLAY('S_PINPON')
+_END()
+```
+
+The above script will unlock player input and will then play the 'S_PINPON' sound effect. The player will be able to move while the sound effect is playing.

--- a/rom-hacking/scripting/commands/logic/157-event-end.md
+++ b/rom-hacking/scripting/commands/logic/157-event-end.md
@@ -1,0 +1,25 @@
+# (157) _EVENT_END
+
+## Synonyms
+
+- [_TALK_END](156-talk-end.md)
+
+## Effect
+
+Unlocks player input in the current script event.
+
+## Syntax
+
+```c
+_EVENT_END()
+```
+
+## Example
+
+```c
+_EVENT_END()
+_SE_PLAY('S_PINPON')
+_END()
+```
+
+The above script will unlock player input and will then play the 'S_PINPON' sound effect. The player will be able to move while the sound effect is playing.


### PR DESCRIPTION
Documented the following commands:
```
(151) _TALK_OBJ_START
(152) _TALK_OBJ_START_TURN_NOT
(153) _TALK_OBJ_END
(154) _TALK_START
(155) _EVENT_START
(156) _TALK_END
(157) _EVENT_END
(218) _ADD_POKEMON
(401) _WILD_BTL_SET
(402) _SP_WILD_BTL_SET
(814) _CAMERA_TARGET_HERO
(815) _CAMERA_TARGET_DUMMY
(816) _DUMMY_ANIME
(817) _DUMMY_ANIME_WAIT
(818) _DUMMY_SET_POS
(819) _DUMMY_SET_POS_HERO
(880) _AC_ANIM_LOCK
(881) _AC_ANIM_RELEASE
(1209) _ADD_POKEMON_UI
(1036) _LOAD_CAMERA_CONTROLLER
(1037) _LOAD_WAIT_CAMERA_CONTROLLER
(1038) _CAMERA_CONTROLLER_PLAY
(1039) _CAMERA_CONTROLLER_END
(1049) _RELEASE_CAMERA_CONTROLLER
(1069) _CAMERA_CONTROLLER_WAIT
(1096) _LOAD_UMA_ANIME
(1097) _RELEASE_UMA_ANIME
(1098) _LOAD_UMA_ANIME_WAIT
(1099) _UMA_ANIME_PLAY
(1100) _UMA_ANIME_ATTACH
(1136) _CAMERA_CONTROLLER_IS_NULL
(1137) _UMA_IS_NULL
```

I can remove `_EVENT_END` if desired, as it is technically a synonym of `_TALK_END`. But I personally see contextual value in using both, when reading scripts.